### PR TITLE
Autogenerate IDs for table head cells

### DIFF
--- a/timbles.js
+++ b/timbles.js
@@ -78,6 +78,10 @@
       var data = $this.data(pluginName);
       if (!data) { return; }
 
+      // ensure all header cells have a legit id
+      data.$headerRow.find('th').not('.no-sort').each(function(i, th) {
+          th.id = th.id || 'timbles-anon-' + $.timblesAnonCount++;
+      });
       // for each header cell, get ID and set the records cells to have it as a class for sorting
       data.$headerRow.find('th').each(function(i){
         var headerId = $(this).attr('id');
@@ -528,6 +532,7 @@
   };
 
   /** module definition */
+  $.timblesAnonCount = 0;
   $.fn[pluginName] = function (method) {
     if ( methods[method] ) {
       return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));

--- a/timbles.js
+++ b/timbles.js
@@ -78,13 +78,10 @@
       var data = $this.data(pluginName);
       if (!data) { return; }
 
-      // ensure all header cells have a legit id
-      data.$headerRow.find('th').not('.no-sort').each(function(i, th) {
-          th.id = th.id || 'timbles-anon-' + $.timblesAnonCount++;
-      });
       // for each header cell, get ID and set the records cells to have it as a class for sorting
       data.$headerRow.find('th').each(function(i){
-        var headerId = $(this).attr('id');
+        // ensure all header cells have a legit id
+        var headerId = this.id = this.id || 'timbles-anon-' + $.timblesAnonCount++;
         data.$records.each(function(j){
           $(this).find('td').eq(i).addClass(headerId);
         });


### PR DESCRIPTION
This PR removes the requirement to explicitly and manually set id attributes for the table column cells that should allow sorting. It does this by generating sequential (and hopefully unique) IDs that are prefixed `timbles-anon-` followed by a global counter value.

The global counter for this (`timblesAnonCount`) is placed on the jQuery object, which is pretty terrible, but I guess it's better than the window, and I lack imagination on where to better place it. If this needs additional tests, or something else is entirely rotten and needs fixing, let me know.
