### PR TITLE
Refactor sortColumn

### DIFF
--- a/timbles.js
+++ b/timbles.js
@@ -86,7 +86,7 @@
           headerId = 'timbles-anon-' + $.timblesAnonCount++;
           $(this).attr('id',headerId);
         }
-        
+
         data.$records.each(function(j){
           $(this).find('td').eq(i).addClass(headerId);
         });
@@ -207,22 +207,21 @@
       var data = $this.data(pluginName);
       if (!data) { return; }
 
-      var $headers = $this.find('th');
+      // determine order and update header sort classes
       var $sortHeader = $this.find('#' + key);
-
-      // determine order and clear header sort classes
       if ( !order ) {
         order = $sortHeader.hasClass(classes.sortASC) ? 'desc' : 'asc';
       }
-      $headers.removeClass(classes.sortASC).removeClass(classes.sortDESC);
+      data.$headerRow.find('th')
+          .removeClass(classes.sortASC)
+          .removeClass(classes.sortDESC);
+      $sortHeader.addClass((order === 'asc') ? classes.sortASC : classes.sortDESC);
 
       // literally sort non-header-row records
       var $recordsToSort = data.$records;
       var $sortedRecords;
 
       if (order === 'asc') {
-        $sortHeader.addClass(classes.sortASC);
-
         var alpha, beta;
         $sortedRecords = $recordsToSort.sort( function(a, b) {
           alpha = $(a).find('td.' + key).data('value');
@@ -245,7 +244,6 @@
         });
       }
       else {
-        $sortHeader.addClass(classes.sortDESC);
         $sortedRecords = $recordsToSort.sort( function(a, b) {
           alpha = $(a).find('td.' + key).data('value');
           beta = $(b).find('td.' + key).data('value');

--- a/timbles.js
+++ b/timbles.js
@@ -217,61 +217,31 @@
           .removeClass(classes.sortDESC);
       $sortHeader.addClass((order === 'asc') ? classes.sortASC : classes.sortDESC);
 
-      // literally sort non-header-row records
-      var $recordsToSort = data.$records;
-      var $sortedRecords;
+      // determine column values to actually sort by
+      var sortMap = data.$records.map(function(index) {
+        var $cell = $(this).find('td.' + key);
+        return {
+            index: index,
+            value: $cell.data('value') || $cell.text()
+        };
+      });
 
-      if (order === 'asc') {
-        var alpha, beta;
-        $sortedRecords = $recordsToSort.sort( function(a, b) {
-          alpha = $(a).find('td.' + key).data('value');
-          beta = $(b).find('td.' + key).data('value');
+      // sort the mapping by the extract column values
+      sortMap.sort(function(a, b) {
+        if (a.value > b.value) {
+          return (order === 'asc') ? 1 : -1;
+        }
+        if (a.value < b.value) {
+          return (order === 'asc') ? -1 : 1;
+        }
+        return 0;
+      });
 
-          alpha = (alpha) ? alpha : $(a).find('td.' + key).text();
-          beta = (beta) ? beta : $(b).find('td.' + key).text();
-
-          if ( alpha < beta ) {
-            return -1;
-          }
-          else {
-            if ( alpha > beta ) {
-              return 1;
-            }
-            else {
-              return 0;
-            }
-          }
-        });
+      // use sortMap to shuffle table rows to the correct order
+      var tableBody = $this.find('tbody').get(0);
+      for (var i = 0; i < sortMap.length; i++) {
+        tableBody.appendChild(data.$records[sortMap[i].index]);
       }
-      else {
-        $sortedRecords = $recordsToSort.sort( function(a, b) {
-          alpha = $(a).find('td.' + key).data('value');
-          beta = $(b).find('td.' + key).data('value');
-
-          alpha = (alpha) ? alpha : $(a).find('td.' + key).text();
-          beta = (beta) ? beta : $(b).find('td.' + key).text();
-
-          if ( beta < alpha ) {
-            return -1;
-          }
-          else {
-            if ( beta > alpha ) {
-              return 1;
-            }
-            else {
-              return 0;
-            }
-          }
-        });
-      }
-
-      // remove current unsorted records
-      if ( $recordsToSort ) {
-        $recordsToSort.remove();
-      }
-
-      // append sorted records
-      $this.append($sortedRecords);
 
       // if table was paginated, reenable
       if ( data.pagination ) {

--- a/timbles.js
+++ b/timbles.js
@@ -238,10 +238,12 @@
       });
 
       // use sortMap to shuffle table rows to the correct order
-      var tableBody = $this.find('tbody').get(0);
+      // work on detached DOM for improved performance on large tables
+      var tableBody = $this.find('tbody').detach().get(0);
       for (var i = 0; i < sortMap.length; i++) {
         tableBody.appendChild(data.$records[sortMap[i].index]);
       }
+      $(tableBody).appendTo($this);
 
       // if table was paginated, reenable
       if ( data.pagination ) {


### PR DESCRIPTION
This PR attempts to clean up the `sortColumn` method by compressing the similar blocks of code used for sorting, using jQuery provided facilities and re-using variables declared at plugin initialization on the table.

Specifically it does the following:
- Removes the `$headers` variable used to find table head cells and uses the already defined `data.$headerRow` for this
- Replaces the inline sort function with a defined sort function:
  - Sort func adds an `order` argument for either ascending or descending operation
  - Performs a single `.find()` for the relevant cell (previous code did a second if data-value was undefined)
  - When used to sort, the rowComparator has its first argument bound reducing its signature to `a,b`  with a locked sort order
- Sort result is applied to current table rather than rows removed and then re-added
- Simplifies class setting for sorted column header

I noticed the change of the (long) boolean short-circuit in the other PR and there's some more stylistic bits here that I'm not sure follow your style. There's some newline-happy method chaining, use of (short and simple) ternaries and another use of boolean short-circuiting. I think they add to readability of the code, but of course preferences differ

If this or anything else needs a change though, I'd be happy to update the PR. (Also, if they don't follow style, do you have a reference document somewhere for that?)
