### PR TITLE
Simplifying and speeding up init and sortMap creation

### DIFF
--- a/timbles.js
+++ b/timbles.js
@@ -223,10 +223,10 @@
 
       // determine column values to actually sort by
       var sortMap = data.$records.map(function(index) {
-        var $cell = $(this).children().eq(sortColumn);
+        var cell = this.children[sortColumn];
         return {
             index: index,
-            value: $cell.data('value') || $cell.text()
+            value: cell.getAttribute('data-value') || cell.textContent || cell.innerText
         };
       });
 

--- a/timbles.js
+++ b/timbles.js
@@ -223,10 +223,14 @@
 
       // determine column values to actually sort by
       var sortMap = data.$records.map(function(index) {
-        var cell = this.children[sortColumn];
+        var cell = this.children[sortColumn],
+            dataValue = cell.getAttribute('data-value');
+        if (parseFloat(dataValue).toString() == dataValue) {
+          dataValue = parseFloat(dataValue);
+        }
         return {
             index: index,
-            value: cell.getAttribute('data-value') || cell.textContent || cell.innerText
+            value: dataValue || cell.textContent || cell.innerText
         };
       });
 

--- a/timbles.js
+++ b/timbles.js
@@ -104,6 +104,7 @@
         }
 
         var $cell = $('<th id="' + value.id + '"' + noSortClassString +'>' + value.label + '</th>');
+        $cell.data('timbles-column-index', index);
         $this.find('tr.' + classes.headerRow).append($cell);
       });
 
@@ -146,7 +147,7 @@
           var displayValue = ( value.dataFilter ) ? value.dataFilter(row[value.id]) : row[value.id];
 
           // append new cell to the row
-          $currentRow.append('<td class="' + value.id + '" data-value="' + row[value.id] + '">' + displayValue + '</td>');
+          $currentRow.append('<td data-value="' + row[value.id] + '">' + displayValue + '</td>');
         });
         thisTable.append($currentRow);
       });

--- a/timbles.js
+++ b/timbles.js
@@ -201,9 +201,16 @@
 
     sortColumn : function(key, order) {
       // Sort a column identified by its key in a given order
+      // If `key` is numeric, it is treated as the column index to sort
       // If `order` is not given, this will do the same as clicking the header
       var $this = $(this);
-      $this.find('#' + key).trigger('click', order);
+      if (typeof key === "number") {
+        var data = $this.data(pluginName);
+        data.$headerRow.find('th').eq(key).trigger('click', order);
+      }
+      else {
+        $this.find('#' + key).trigger('click', order);
+      }
     },
 
     sortColumnEvent : function(event, order) {

--- a/timbles.js
+++ b/timbles.js
@@ -195,20 +195,26 @@
       if (!data) { return; }
 
       // bind sorting to header cells
-      $this.find('th').not('.no-sort').bind({
-        click: function(e) {
-          methods.sortColumn.call($this, $(this).attr('id'), false);
-        }
-      });
+      $this.find('th').not('.no-sort').on(
+          'click', methods.sortColumnEvent.bind($this));
     },
 
     sortColumn : function(key, order) {
+      // Sort a column identified by its key in a given order
+      // If `order` is not given, this will do the same as clicking the header
+      var $this = $(this);
+      $this.find('#' + key).trigger('click', order);
+    },
+
+    sortColumnEvent : function(event, order) {
       var $this = $(this);
       var data = $this.data(pluginName);
       if (!data) { return; }
 
       // determine order and update header sort classes
-      var $sortHeader = $this.find('#' + key);
+      var $sortHeader = $(event.target);
+      var key = $sortHeader.attr('id');
+
       if ( !order ) {
         order = $sortHeader.hasClass(classes.sortASC) ? 'desc' : 'asc';
       }

--- a/timbles.js
+++ b/timbles.js
@@ -78,18 +78,9 @@
       var data = $this.data(pluginName);
       if (!data) { return; }
 
-      // for each header cell, get ID and set the records cells to have it as a class for sorting
+      // for each header cell, store its column number
       data.$headerRow.find('th').each(function(i){
-        // ensure all header cells have a legit id
-        var headerId = $(this).attr('id');
-        if ( !headerId ) {
-          headerId = 'timbles-anon-' + $.timblesAnonCount++;
-          $(this).attr('id',headerId);
-        }
-
-        data.$records.each(function(j){
-          $(this).find('td').eq(i).addClass(headerId);
-        });
+        $(this).data('timbles-column-index', i);
       });
 
       // start enabling any given features
@@ -220,7 +211,7 @@
 
       // determine order and update header sort classes
       var $sortHeader = $(event.target);
-      var key = $sortHeader.attr('id');
+      var sortColumn = $sortHeader.data('timbles-column-index');
 
       if ( !order ) {
         order = $sortHeader.hasClass(classes.sortASC) ? 'desc' : 'asc';
@@ -232,7 +223,7 @@
 
       // determine column values to actually sort by
       var sortMap = data.$records.map(function(index) {
-        var $cell = $(this).find('td.' + key);
+        var $cell = $(this).children().eq(sortColumn);
         return {
             index: index,
             value: $cell.data('value') || $cell.text()
@@ -520,7 +511,6 @@
   };
 
   /** module definition */
-  $.timblesAnonCount = 0;
   $.fn[pluginName] = function (method) {
     if ( methods[method] ) {
       return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));

--- a/timbles.js
+++ b/timbles.js
@@ -222,14 +222,14 @@
       $sortHeader.addClass((order === 'asc') ? classes.sortASC : classes.sortDESC);
 
       // determine column values to actually sort by
-      var sortMap = data.$records.map(function(index) {
+      var sortMap = data.$records.map(function() {
         var cell = this.children[sortColumn],
             dataValue = cell.getAttribute('data-value');
         if (parseFloat(dataValue).toString() == dataValue) {
           dataValue = parseFloat(dataValue);
         }
         return {
-            index: index,
+            node: this,
             value: dataValue || cell.textContent || cell.innerText
         };
       });
@@ -248,12 +248,12 @@
       // use sortMap to shuffle table rows to the correct order
       // work on detached DOM for improved performance on large tables
       var tableBody = $this.find('tbody').detach().get(0);
-      for (var i = 0; i < sortMap.length; i++) {
-        tableBody.appendChild(data.$records[sortMap[i].index]);
-      }
-      
+      sortMap.each(function() {
+        tableBody.appendChild(this.node);
+      });
+
       $(tableBody).appendTo($this);
-      
+
       data.$allRows = $this.find('tr');
       data.$records = data.$allRows.not('.' + classes.headerRow);
       $this.data(pluginName, data);


### PR DESCRIPTION
This PR speeds up Timbles initialization and the creation of the sortMap used to actually sort the table based on the selected column.

Initialization no longer uses the IDs of the column headers at all (though these can still be used as sorting targets like before), and simply stores a column index as (jQuery) data attribute on each header. A significant speedup is accomplished by adding a class to each and every `tbody td`. This significantly reduces setup time for large tables.

This change of initialization also removes the need for the `timblesAnonCount` global variable used to assign unique IDs to column heads.

Second is a change to the event handler for the click, this is now handled by `sortColumnEvent`, and `sortColumn` is maintained as public API for script access. The revised `sortColumn()` function can either sort by ID string of the column as before, or numeric 0-based index.

With the change from class-based to position-based extraction of the correct column comes the opportunity to do this in native JS/DOM, which makes sortMap about an order of magnitude faster. This is due to accessing child elements of the `<tr>` directly and retrieving the nth element needed, as well as using native getters for the data attribute (with jQuery style automatic conversion of numbers) and text nodes (including IE's non-standard attribute).

The sortMap has also been changed to store a reference to the entire row rather than its index, making the shuffling of rows post-sort a more understandable `.each()` call.

The time taken by `sortColumnEvent()` for my 2300 row test table is now down to ~110ms (from ~200ms before), and is dominated by the detaching of the `<tbody>`:
- Creating the sortMap takes ~**5ms**
- Actually sorting it takes ~**5ms**
- Detaching the tbody ~**80ms**
- Shuffling rows based on the sortMap\* ~**20ms**  
  * Reattaching is also done in this time

Not detaching slows the shuffling down by over an order of magnitude (20ms to 250ms). There appears to be no speeding up the detaching significantly (setting `innerHTML`, using `Node.removeChild()` or `Node.replaceChild()`), so this seems to be as fast as it reasonably gets.

There's probably some documentation / tests that should be updated/added as well, but I wanted to get this rolling as it's been sitting for too long.
