### PR TITLE
Refactor tests

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -5,11 +5,12 @@
   <title>timbles tests &bull; QUnit</title>
 </head>
 <body>
-  
+
   <h1>timbles tests</h1>
 
 <ul>
   <li><a href="timbles.html">existing html table</a></li>
+  <li><a href="timbles-id-free.html">existing html table (without IDs)</a></li>
   <li><a href="timbles-json.html">data pulled from json file</a></li>
   <li><a href="timbles-array.html">data pulled internally</a></li>
   <li><a href="timbles-filters.html">data filter functions applied to cells</a></li>

--- a/tests/test-scripts/init.js
+++ b/tests/test-scripts/init.js
@@ -1,16 +1,16 @@
 /* testing initialization of timbles tables */
 
-QUnit.test( 'Correct Number of Table Rows', function( assert ) {
+QUnit.test('Correct Number of Table Rows', function(assert) {
   var numRows = $('table').find('tr').length;
-  assert.ok( numRows === 9, 'Passed!' );
-}); 
+  assert.equal(numRows, 9);
+});
 
-QUnit.test( 'Detect single Header Row', function( assert ) {
+QUnit.test('Detect single Header Row', function(assert) {
   var numRows = $('table').find('tr.header-row').length;
-  assert.ok( numRows === 1, 'Passed!' );
-}); 
+  assert.equal(numRows, 1);
+});
 
-QUnit.test( 'Correct Number of Non-header Record Rows', function( assert ) {
+QUnit.test('Correct Number of Non-header Record Rows', function(assert) {
   var numRows = $('table').find('tr').not('.header-row').length;
-  assert.ok( numRows === 8, 'Passed!' );
+  assert.equal(numRows, 8);
 });

--- a/tests/test-scripts/pagination.js
+++ b/tests/test-scripts/pagination.js
@@ -1,19 +1,16 @@
 /* testing pagination of timbles tables */
 
-QUnit.test( 'Correct Number of Table Rows Showing on Page', function( assert ) {
+QUnit.test('Correct number of table rows showing on page', function(assert) {
   var numRows = $('table').find('tr').length;
-  console.log('# rows altogether', numRows);
-  assert.ok( numRows === 4, 'Passed!' );
-}); 
+  assert.equal(numRows, 4);
+});
 
-QUnit.test( 'Detect single Header Row', function( assert ) {
+QUnit.test( 'Detect single header row', function( assert ) {
   var numRows = $('table').find('tr.header-row').length;
-  console.log('# header rows', numRows);
-  assert.ok( numRows === 1, 'Passed!' );
-}); 
+  assert.equal(numRows, 1);
+});
 
-QUnit.test( 'Correct Number of Non-header Record Rows', function( assert ) {
+QUnit.test('Correct number of non-header record rows', function( assert ) {
   var numRows = $('table').find('tr').not('.header-row').length;
-  console.log('# records', numRows);
-  assert.ok( numRows === 3, 'Passed!' );
+  assert.ok(numRows, 3);
 });

--- a/tests/test-scripts/sorting.js
+++ b/tests/test-scripts/sorting.js
@@ -3,14 +3,13 @@
 QUnit.test( 'Clicking a column header sorts table by that column', function( assert) {
   var $aColumnHeader = $('thead tr').eq(0).find('th').eq(2);
   $aColumnHeader.click();
-  assert.ok( $('tbody tr').eq(0).find('td').eq(2).text() === 'Adobe PDF document', 'Passed!' );
+  assert.equal($('tbody tr').eq(0).find('td').eq(2).text(), 'Adobe PDF document');
 });
 
-
-var $noSortColumns = $('.no-sort');
-  if ( $noSortColumns.length > 0 ) {
-    QUnit.test( 'Header with no-sort class is not sortable', function( assert ) {
-    $noSortColumns.click();
-    assert.ok( !$noSortColumns.hasClass('sorted-asc') && !$noSortColumns.hasClass('sorted-desc'), 'Passed!' );
-  });
-}
+QUnit.test('There is one unsortable header and sorting by it does nothing', function(assert) {
+  var $noSortColumns = $('.no-sort');
+  assert.equal($noSortColumns.length, 1, 'There is one unsortable column');
+  $noSortColumns.click();
+  assert.ok(!$noSortColumns.hasClass('sorted-asc'), 'Not sorted ascending');
+  assert.ok(!$noSortColumns.hasClass('sorted-desc'), 'Not sorted descending');
+});

--- a/tests/timbles-id-free.html
+++ b/tests/timbles-id-free.html
@@ -17,7 +17,7 @@
         <th>Size</th>
         <th>Kind</th>
         <th>Date Added</th>
-        <th>Notes</th>
+        <th class="no-sort">Notes</th>
       </tr>
     </thead>
     <tr>
@@ -26,7 +26,7 @@
       <td>PNG Image</td>
       <td>August 31, 2014, 11:16 PM</td>
       <td>dhtmlconf logo</td>
-    </tr>      
+    </tr>
     <tr>
       <td>icla.pdf</td>
       <td>26 KB</td>
@@ -61,14 +61,14 @@
       <td>Plain Text File</td>
       <td>May 24, 2014, 1:55 PM</td>
       <td>logo for jort.technology</td>
-    </tr>      
+    </tr>
     <tr>
       <td>wordpress.sql</td>
       <td>418 KB</td>
       <td>Plain Text File</td>
       <td>May 11, 2014, 11:15 PM</td>
       <td>blog dump</td>
-    </tr>      
+    </tr>
     <tr>
       <td>foundation-compass-template-master.zip</td>
       <td>6 KB</td>

--- a/tests/timbles.html
+++ b/tests/timbles.html
@@ -17,7 +17,7 @@
         <th id="size">Size</th>
         <th id="kind">Kind</th>
         <th id="date-added">Date Added</th>
-        <th id="notes">Notes</th>
+        <th class="no-sort" id="notes">Notes</th>
       </tr>
     </thead>
     <tr>
@@ -26,7 +26,7 @@
       <td>PNG Image</td>
       <td>August 31, 2014, 11:16 PM</td>
       <td>dhtmlconf logo</td>
-    </tr>      
+    </tr>
     <tr>
       <td>icla.pdf</td>
       <td>26 KB</td>
@@ -61,14 +61,14 @@
       <td>Plain Text File</td>
       <td>May 24, 2014, 1:55 PM</td>
       <td>logo for jort.technology</td>
-    </tr>      
+    </tr>
     <tr>
       <td>wordpress.sql</td>
       <td>418 KB</td>
       <td>Plain Text File</td>
       <td>May 11, 2014, 11:15 PM</td>
       <td>blog dump</td>
-    </tr>      
+    </tr>
     <tr>
       <td>foundation-compass-template-master.zip</td>
       <td>6 KB</td>
@@ -77,7 +77,7 @@
       <td>c.s.s. is better that javascript</td>
     </tr>
   </table>
-  
+
 <script type="text/javascript" src="../jquery.js"></script>
 <script type="text/javascript" src="../timbles.js"></script>
 
@@ -99,6 +99,6 @@ $(function() {
   <script src="qunit-1.15.0.js"></script>
   <script src="test-scripts/init.js"></script>
   <script src="test-scripts/sorting.js"></script>
-  
+
 </body>
 </html>


### PR DESCRIPTION
This PR changes a few small things about the current tests, but doesn't do anything new or exciting:
- Adds the ID-free suite to the index page
- Uses `.equal()` where comparisons are being made, which does a better job of it than `.ok()`
- Removes assertion descriptions where they contained success messages (removing the weirdness of failed tests saying "Passed!")
- Always tests for an unsortable column, rather than having the test be conditional. Some suites have been updated to accommodate this.

There's some additional whitespace trimming going on courtesy of my editor, causing the diff to be a little larger than strictly necessary.
