### PR TITLE
Text and value transforms

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -151,16 +151,20 @@ $table.timbles({
       * and here are some optional properties:
       * - noSorting (boolean), if set to true the column won't be sortable
       *   if you have the non-column property sorting set to true
-      * - dataFilter (function), this function will be applied to the cell value,
-      *   useful for when you want to add currency symbols, html, etc
+      * - textTransform (function), this function will be applied to the cell text
+      *   content. useful for when you want to add currency symbols, html, etc
+      *   (the old name for this function is `dataFilter`, we still support that one)
+      * - valueTransform (function), this function will be applied to the data-value
+      *   attribute, which is used for sorting. Useful if you want a column to
+      *   sort case insensitively.
       */
 
-      { label: 'Name', id: 'name' },
+      { label: 'Name', id: 'name', valueTransform: function(value) { return value.toLowerCase(); } },
       { label: 'Size', id: 'size' },
       { label: 'Kind', id: 'kind' },
       { label: 'Date Added', id: 'dateAdded' },
       { label: 'Notes', id: 'notes', noSorting: true }
-      { label: 'Price', id: 'price', dataFilter: function(value) { return '$' + value; } }
+      { label: 'Price', id: 'price', textTransform: function(value) { return '$' + value; } }
     ]
   }
   sorting: true, // if you want columns to be sortable

--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ Let's say you have a table on your page already, all populated with data:
     <td>PNG Image</td>
     <td>August 31, 2014, 11:16 PM</td>
     <td>dhtmlconf logo</td>
-  </tr>      
+  </tr>
   <tr>
     <td>icla.pdf</td>
     <td>26 KB</td>
@@ -72,7 +72,7 @@ And here is the source code:
     <td>PNG Image</td>
     <td>August 31, 2014, 11:16 PM</td>
     <td>dhtmlconf logo</td>
-  </tr>      
+  </tr>
   <tr>
     <td>icla.pdf</td>
     <td>26 KB</td>
@@ -133,30 +133,25 @@ var $table = $('#example');
 $table.timbles({
 
   dataConfig: {
-    
+
       /**
       * There are two types of data that timbles currently accepts:
       * - a json filename
       * - an array of row objects
-      * 
-      * by default, timbles will look for a json file name, 
-      * so dataType is not required unless you are giving an array.
-      * Then you will need to set it to 'array'.
       */
-      
-    dataType: 'json', // right now data types can be 'array' or it defaults to 'json'
-    data: 'data.json', // the json file if dataType is 'json', an array if dataType is 'array'
+
+    data: 'data.json', // path to load json file from, or an array of row objects
     columns: [
-      
+
       /**
       * you have to set the column headers with the following required properties:
       * - label (string), the text between <th> and </th>
       * - id (string), the json object property attributed to the column
-      * 
+      *
       * and here are some optional properties:
-      * - noSorting (boolean), if set to true the column won't be sortable 
+      * - noSorting (boolean), if set to true the column won't be sortable
       *   if you have the non-column property sorting set to true
-      * - dataFilter (function), this function will be applied to the cell value, 
+      * - dataFilter (function), this function will be applied to the cell value,
       *   useful for when you want to add currency symbols, html, etc
       */
 
@@ -248,7 +243,7 @@ var $table = $('table');
 $table.timbles(
   pagination: {
     recordsPerPage: 5, // an integer value for how many records per page, for example 5
-    
+
     // for navigation tools, each nav object is appended to a "pagination" div container below the table in the order they are listed
     nav: {
       arrows: true, // the default first/prev/next/last arrow buttons for navigating

--- a/tests/timbles-array.html
+++ b/tests/timbles-array.html
@@ -23,7 +23,7 @@ $(function() {
 
   /* it's going down
       i'm yellin' timbles! */
-      
+
   var localData = [
     {
       name: "LOCAL dhtmlconf.png",
@@ -79,10 +79,9 @@ $(function() {
 
 
   $table.timbles({
-    
+
     // if you are using json data and not an existing table:
     dataConfig: {
-      dataType: 'array',
       data: localData,
       columns: [
         { label: 'Name', id: 'name' },

--- a/timbles.js
+++ b/timbles.js
@@ -111,10 +111,10 @@
       // generate each row of data from json
       var rows;
 
-      if ( data.dataConfig.dataType === 'array' ) {
+      if ($.isArray(data.dataConfig.data)) {
         // no need for ajax call if data is local array
         methods.generateRowsFromData.call($this, data.dataConfig.data, data.dataConfig.columns, $this);
-        
+
         // start enabling any given features
         methods.enableFeaturesSetup.call($this);
       }

--- a/timbles.js
+++ b/timbles.js
@@ -123,14 +123,6 @@
         $.getJSON( data.dataConfig.data, function(json) {
           methods.generateRowsFromData.call($this, json, data.dataConfig.columns, $this);
         }).then(function(){
-          // set up existing html table
-          data.$allRows = $this.find('tr');
-          data.$headerRow = $this.find('thead tr').eq(0).addClass(classes.headerRow);
-          data.$records = data.$allRows.not('.' + classes.headerRow);
-
-          // save all this great new data wowowow
-          $this.data(pluginName, data);
-
           // start enabling any given features
           methods.enableFeaturesSetup.call($this);
         });


### PR DESCRIPTION
This PR adds the `textTransform` and `valueTransform` properties to the column configuration for tables generated from either JSON or local array data. It resolves #16 and allows work done in #14 to be used in all suites, allowing better tests in general.

It also removes the `dataType` property from the same table configuration, since we can easily detect whether or not the caller has supplied an array or a string that points to a JSON source.

The `parseDataConfig` method checks the dataConfig provided when initializing timbles, setting default transform functions for all columns that don't define their own. Columns that define a `dataFilter` but no `textTransform` will use that function for text transformation. Having all columns provide these functions keeps code further down clearer (removing ternaries).

Documentation for dataType has been removed, transformation functions have been added there, and the filter test suite has been updated to use the new textTransform property.
