### PR TITLE
New year's code cleanup

### DIFF
--- a/timbles.js
+++ b/timbles.js
@@ -106,44 +106,36 @@
     },
 
     generateTableFromJson : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
-
-      $this.append('<thead><tr class="' + classes.headerRow + '"></tr></thead>');
-      data.$headerRow = $this.find('tr.' + classes.headerRow);
+      var data = this.data(pluginName);
+      var $headerRow = data.$headerRow = $('<tr>')
+        .addClass(classes.headerRow)
+        .appendTo($('<thead>').appendTo(this));
 
       // generate and add cell headers to header row
-      $.each(data.dataConfig.columns, function(index, value){
-
-        // if noSorting is set for this column, add the no-sort class to it
-        var noSortClassString = '';
-        if ( value.noSorting ) {
-          noSortClassString = ' class="' + classes.noSort + '"';
-        }
-
-        var $cell = $('<th id="' + value.id + '"' + noSortClassString +'>' + value.label + '</th>');
-        $cell.data('timbles-column-index', index);
-        data.$headerRow.append($cell);
+      $.each(data.dataConfig.columns, function(index, value) {
+        $('<th>')
+          .attr('id', value.id)
+          .addClass(value.noSorting ? classes.noSort : null)
+          .data('timbles-column-index', index)
+          .text(value.label)
+          .appendTo($headerRow);
       });
-
-      // generate each row of data from json
-      var rows;
 
       if ($.isArray(data.dataConfig.data)) {
         // no need for ajax call if data is local array
-        methods.generateRowsFromData.call($this, data.dataConfig.data, data.dataConfig.columns, $this);
+        methods.generateRowsFromData.call(this, data.dataConfig.data, data.dataConfig.columns);
 
         // start enabling any given features
-        methods.enableFeaturesSetup.call($this);
+        methods.enableFeaturesSetup.call(this);
       }
       else {
         // get external json file given
         $.getJSON( data.dataConfig.data, function(json) {
-          methods.generateRowsFromData.call($this, json, data.dataConfig.columns, $this);
-        }).then(function(){
+          methods.generateRowsFromData.call(this, json, data.dataConfig.columns);
+        }.bind(this)).then(function(){
           // start enabling any given features
-          methods.enableFeaturesSetup.call($this);
-        });
+          methods.enableFeaturesSetup.call(this);
+        }.bind(this));
       }
     },
 

--- a/timbles.js
+++ b/timbles.js
@@ -268,9 +268,9 @@
     generatePaginationTools : function() {
       var data = this.data(pluginName);
 
-      // create pagination container and place after table
-      data.$paginationToolsContainer = $('<div class="' + classes.paginationToolsContainer + '">');
-      this.after(data.$paginationToolsContainer);
+      data.$paginationToolsContainer = $('<div>')
+        .addClass(classes.paginationToolsContainer)
+        .insertAfter(this);
 
       if ( !data.pagination.nav ) {
         // by default, just show arrow nav
@@ -303,20 +303,23 @@
       data.$linkPrevPage = $('<button role="button">').text(copy.prevPageArrow);
       data.$linkNextPage = $('<button role="button">').text(copy.nextPageArrow);
       data.$linkLastPage = $('<button role="button">').text(copy.lastPageArrow);
-      data.$pageNumberTracker = $('<span>')
+      var $pageNumberTracker = $('<span>')
         .addClass('page-number-tracker')
         .text(copy.page + ' ')
         .append($('<span>').addClass('pointer-this-page').text(data.pagination.currentPage))
         .append(' ' + copy.of + ' ')
         .append($('<span>').addClass('pointer-last-page').text(data.pagination.lastPage));
 
-      data.$paginationNavArrows = $('<div>')
+      data.$pointerThisPage = $pageNumberTracker.find('.pointer-this-page');
+      data.$pointerLastPage = $pageNumberTracker.find('.pointer-last-page');
+      $('<div>')
         .addClass(classes.paginationNavArrows)
         .append(data.$linkFirstPage)
         .append(data.$linkPrevPage)
-        .append(data.$pageNumberTracker)
+        .append($pageNumberTracker)
         .append(data.$linkNextPage)
-        .append(data.$linkLastPage);
+        .append(data.$linkLastPage)
+        .appendTo(data.$paginationToolsContainer);
 
       // event listeners
       data.$linkFirstPage.click(function(){
@@ -338,38 +341,33 @@
       data.$linkLastPage.click(function(){
         methods.goToPage.call(this, data.pagination.lastPage);
       }.bind(this));
-
-      data.$paginationToolsContainer.append(data.$paginationNavArrows);
-      data.$pointerThisPage = data.$paginationToolsContainer.find('.pointer-this-page');
-      data.$pointerLastPage = data.$paginationToolsContainer.find('.pointer-last-page');
     },
 
     generatePaginationNavRowCountChoice : function() {
       var data = this.data(pluginName);
-      var optionCount = data.pagination.nav.rowCountChoice.length;
-      var arrayOfChoices = [];
 
-      for ( var i = 0; i < optionCount; i++ ) {
-        arrayOfChoices.push('<button role="button">' + data.pagination.nav.rowCountChoice[i] + '</button>');
-      }
+      data.$paginationNavRowCountChoice = $('<div>')
+        .addClass(classes.paginationNavRowCountChoice)
+        .appendTo(data.$paginationToolsContainer);
 
-      data.$paginationNavRowCountChoice = $('<div>').attr('class', classes.paginationNavRowCountChoice).append(arrayOfChoices);
+      $.each(data.pagination.nav.rowCountChoice, function() {
+        $('<button>')
+          .attr('role', 'button')
+          .text(this)
+          .appendTo(data.$paginationNavRowCountChoice);
+      });
 
       // event listeners
       data.$paginationNavRowCountChoice.find('button').click(function(event){
-        var $target = $(event.target);
+        var $target = $(event.target).addClass(classes.active)
         var newRowCount = $target.text();
-        // make clicked button only active one
-        data.$paginationNavRowCountChoice.find('button').removeClass(classes.active);
-        $target.addClass(classes.active);
+        $target.siblings().removeClass(classes.active);
 
         if ( newRowCount.toLowerCase() === 'all' ) {
           newRowCount = data.$records.length;
         }
         methods.enablePagination.call(this, parseInt(newRowCount));
       }.bind(this));
-
-      data.$paginationToolsContainer.append(data.$paginationNavRowCountChoice);
     },
 
     updatePaginationTools : function() {

--- a/timbles.js
+++ b/timbles.js
@@ -147,21 +147,19 @@
       }
     },
 
-    generateRowsFromData : function(rowData, columnConfig, thisTable) {
-      var $this = $(this);
-      var data = $this.data(pluginName);
-
+    generateRowsFromData : function(rowData, columnConfig) {
       $.each(rowData, function(index, row) {
-        var $currentRow = $('<tr>');
+        // Add rows to the current table
+        var $newRow = $('<tr>').appendTo(this);
         $.each(columnConfig, function(index, column) {
-          var cellValue = row[column.id],
-              $currentCell = $('<td>');
-          $currentCell.attr('data-value', column.valueTransform(cellValue));
-          $currentCell.text(column.textTransform(cellValue));
-          $currentCell.appendTo($currentRow);
-        });
-        $currentRow.appendTo(thisTable);
-      });
+          // Add cells to the current row
+          var cellValue = row[column.id];
+          $('<td>')
+            .attr('data-value', column.valueTransform(cellValue))
+            .text(column.textTransform(cellValue))
+            .appendTo(this);
+        }.bind($newRow));
+      }.bind(this));
     },
 
     enableFeaturesSetup : function() {

--- a/timbles.js
+++ b/timbles.js
@@ -91,18 +91,17 @@
     },
 
     setupExistingTable : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
+      var data = this.data(pluginName);
 
       // for each header cell, store its column number
-      var $headerRow = data.$headerRow = $this.find('thead tr').eq(0)
+      var $headerRow = data.$headerRow = this.find('thead tr').eq(0)
         .addClass(classes.headerRow);
       $headerRow.find('th').each(function(index) {
         $(this).data('timbles-column-index', index);
       });
 
       // start enabling any given features
-      methods.enableFeaturesSetup.call($this);
+      methods.enableFeaturesSetup.call(this);
     },
 
     generateTableFromJson : function() {
@@ -155,25 +154,20 @@
     },
 
     enableFeaturesSetup : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
+      var data = this.data(pluginName);
       data.$records = this.find('tbody tr');
 
-     // if sorting set to true, allow sorting
       if ( data.sorting ) {
-        methods.enableSorting.call($this);
+        methods.enableSorting.call(this);
 
-        // if sorting is given, sort table by it and order
         if ( data.sorting.keyId ) {
-          methods.sortColumn.call($this, data.sorting.keyId, data.sorting.order);
+          methods.sortColumn.call(this, data.sorting.keyId, data.sorting.order);
         }
       }
 
-      // if pagination set to true, set pagination
       if ( data.pagination ) {
-        methods.enablePagination.call($this, data.pagination.recordsPerPage);
+        methods.enablePagination.call(this, data.pagination.recordsPerPage);
       }
-
     },
 
     enableSorting : function() {
@@ -185,19 +179,17 @@
       // Sort a column identified by its key in a given order
       // If `key` is numeric, it is treated as the column index to sort
       // If `order` is not given, this will do the same as clicking the header
-      var $this = $(this);
       if (typeof key === "number") {
-        var data = $this.data(pluginName);
+        var data = this.data(pluginName);
         data.$headerRow.find('th').eq(key).trigger('click', order);
       }
       else {
-        $this.find('#' + key).trigger('click', order);
+        this.find('#' + key).trigger('click', order);
       }
     },
 
     sortColumnEvent : function(event, order) {
-      var $this = $(this);
-      var data = $this.data(pluginName);
+      var data = this.data(pluginName);
 
       // determine order and update header sort classes
       var $sortHeader = $(event.target);
@@ -213,8 +205,8 @@
 
       // determine column values to actually sort by
       var sortMap = data.$records.map(function() {
-        var cell = this.children[sortColumn],
-            dataValue = cell.getAttribute('data-value');
+        var cell = this.children[sortColumn];
+        var dataValue = cell.getAttribute('data-value');
         if (dataValue === null) {
           dataValue = cell.textContent || cell.innerText;
         }
@@ -240,12 +232,12 @@
 
       // use sortMap to shuffle table rows to the correct order
       // work on detached DOM for improved performance on large tables
-      var tableBody = $this.find('tbody').detach().get(0);
+      var tableBody = this.find('tbody').detach().get(0);
       sortMap.each(function() {
         tableBody.appendChild(this.node);
       });
 
-      $(tableBody).appendTo($this);
+      $(tableBody).appendTo(this);
 
       // if table was paginated, reenable
       if ( data.pagination ) {
@@ -255,8 +247,7 @@
     },
 
     enablePagination : function(count) {
-      var $this = $(this);
-      var data = $this.data(pluginName);
+      var data = this.data(pluginName);
       // don't paginate if there are no records
       if (!data.$records || data.$records.length === 0 ) { return; }
 
@@ -272,10 +263,10 @@
       // show the first page and set page counter
       data.$records.remove();
       data.pagination.currentPage = 1;
-      $this.append(paginatedRecordsArray);
+      this.append(paginatedRecordsArray);
 
       // create footer to hold tools
-      data.$footerRow = $this.find('tfoot');
+      data.$footerRow = this.find('tfoot');
 
       if ( data.$footerRow.length === 0 ) {
         var $footer = $('<tfoot>');
@@ -284,25 +275,24 @@
 
       // create tools if they don't exist already
       if ( !data.$paginationToolsContainer ) {
-        methods.generatePaginationTools.call($this);
+        methods.generatePaginationTools.call(this);
       }
       else {
         // update existing pagination tools
-        methods.updatePaginationTools.call($this);
+        methods.updatePaginationTools.call(this);
       }
     },
 
     generatePaginationTools : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
+      var data = this.data(pluginName);
 
       // create pagination container and place after table
       data.$paginationToolsContainer = $('<div class="' + classes.paginationToolsContainer + '">');
-      $this.after(data.$paginationToolsContainer);
+      this.after(data.$paginationToolsContainer);
 
       if ( !data.pagination.nav ) {
         // by default, just show arrow nav
-        methods.generatePaginationNavArrows.call($this);
+        methods.generatePaginationNavArrows.call(this);
       }
       else {
         // iterate through nav object and add tools to footer
@@ -310,24 +300,22 @@
           switch (navObject) {
             // arrows
             case "arrows":
-              methods.generatePaginationNavArrows.call($this);
+              methods.generatePaginationNavArrows.call(this);
               break;
             // row count choice
             case "rowCountChoice":
-              methods.generatePaginationNavRowCountChoice.call($this);
+              methods.generatePaginationNavRowCountChoice.call(this);
               break;
           }
         }
       }
 
       // update tools
-      methods.updatePaginationTools.call($this);
+      methods.updatePaginationTools.call(this);
     },
 
     generatePaginationNavArrows : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
-
+      var data = this.data(pluginName);
       var thisPage = 1;
       var lastPage = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
 
@@ -347,28 +335,28 @@
 
       // event listeners
       data.$linkFirstPage.click(function(){
-        methods.goToPage.call($this, 1);
-      });
+        methods.goToPage.call(this, 1);
+      }.bind(this));
 
       data.$linkPrevPage.click(function(){
         var newPage = data.pagination.currentPage - 1;
 
         if ( newPage >= 1 ) {
-          methods.goToPage.call($this, newPage);
+          methods.goToPage.call(this, newPage);
         }
-      });
+      }.bind(this));
 
       data.$linkNextPage.click(function(){
         var newPage = data.pagination.currentPage + 1;
 
         if ( newPage <= Math.ceil(data.$records.length / data.pagination.recordsPerPage) ) {
-          methods.goToPage.call($this, newPage);
+          methods.goToPage.call(this, newPage);
         }
-      });
+      }.bind(this));
 
       data.$linkLastPage.click(function(){
-        methods.goToPage.call($this, Math.ceil(data.$records.length / data.pagination.recordsPerPage));
-      });
+        methods.goToPage.call(this, Math.ceil(data.$records.length / data.pagination.recordsPerPage));
+      }.bind(this));
 
       data.$paginationToolsContainer.append(data.$paginationNavArrows);
       data.$pointerThisPage = data.$paginationToolsContainer.find('.pointer-this-page');
@@ -376,9 +364,7 @@
     },
 
     generatePaginationNavRowCountChoice : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
-
+      var data = this.data(pluginName);
       var optionCount = data.pagination.nav.rowCountChoice.length;
       var arrayOfChoices = [];
 
@@ -389,25 +375,24 @@
       data.$paginationNavRowCountChoice = $('<div>').attr('class', classes.paginationNavRowCountChoice).append(arrayOfChoices);
 
       // event listeners
-      data.$paginationNavRowCountChoice.find('button').click(function(){
-
+      data.$paginationNavRowCountChoice.find('button').click(function(event){
+        var $target = $(event.target);
+        var newRowCount = $target.text();
+        // make clicked button only active one
         data.$paginationNavRowCountChoice.find('button').removeClass(classes.active);
-        $(this).addClass(classes.active);
+        $target.addClass(classes.active);
 
-        var newRowCount = $(this).text();
         if ( newRowCount.toLowerCase() === 'all' ) {
           newRowCount = data.$records.length;
         }
-        methods.enablePagination.call($this, newRowCount);
-      });
+        methods.enablePagination.call(this, newRowCount);
+      }.bind(this));
 
       data.$paginationToolsContainer.append(data.$paginationNavRowCountChoice);
     },
 
     updatePaginationTools : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
-
+      var data = this.data(pluginName);
       var min = 1;
       var max = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
 
@@ -436,8 +421,7 @@
     },
 
     goToPage : function(page) {
-      var $this = $(this);
-      var data = $this.data(pluginName);
+      var data = this.data(pluginName);
 
       // check for valid page number
       var pageCount = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
@@ -448,7 +432,7 @@
       // move to next page
       data.pagination.currentPage = page;
 
-      $this.find('tr').not('.'+classes.headerRow).remove();
+      this.find('tr').not('.'+classes.headerRow).remove();
 
       var paginatedRecordsArray = [];
       var newFirstRowNum = (page - 1) * (data.pagination.recordsPerPage) + 1,
@@ -466,12 +450,11 @@
       }
 
       // add rows to table
-      $this.find('tbody').append(paginatedRecordsArray);
+      this.find('tbody').append(paginatedRecordsArray);
 
       // update pagination tools
-      methods.updatePaginationTools.call($this);
+      methods.updatePaginationTools.call(this);
     },
-
   };
 
   /** module definition */

--- a/timbles.js
+++ b/timbles.js
@@ -319,14 +319,19 @@
       var thisPage = 1;
       var lastPage = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
 
-      data.$paginationNavArrows = $('<div class="' + classes.paginationNavArrows + '">');
-      data.$linkFirstPage = $('<button role="button">' + copy.firstPageArrow + '</button>');
-      data.$linkPrevPage = $('<button role="button">' + copy.prevPageArrow + '</a>');
-      data.$linkNextPage = $('<button role="button">' + copy.nextPageArrow + '</a>');
-      data.$linkLastPage = $('<button role="button">' + copy.lastPageArrow + '</a>');
-      data.$pageNumberTracker = $('<span class="page-number-tracker">' + copy.page + ' <span class="pointer-this-page">' + thisPage + '</span> ' + copy.of + ' <span class="pointer-last-page">' + lastPage + '</span></span>');
+      data.$linkFirstPage = $('<button role="button">').text(copy.firstPageArrow);
+      data.$linkPrevPage = $('<button role="button">').text(copy.prevPageArrow);
+      data.$linkNextPage = $('<button role="button">').text(copy.nextPageArrow);
+      data.$linkLastPage = $('<button role="button">').text(copy.lastPageArrow);
+      data.$pageNumberTracker = $('<span>')
+        .addClass('page-number-tracker')
+        .text(copy.page + ' ')
+        .append($('<span>').addClass('pointer-this-page').text(thisPage))
+        .append(' ' + copy.of + ' ')
+        .append($('<span>').addClass('pointer-last-page').text(lastPage));
 
-      data.$paginationNavArrows
+      data.$paginationNavArrows = $('<div>')
+        .addClass(classes.paginationNavArrows)
         .append(data.$linkFirstPage)
         .append(data.$linkPrevPage)
         .append(data.$pageNumberTracker)

--- a/timbles.js
+++ b/timbles.js
@@ -268,14 +268,6 @@
       data.$records.remove();
       this.append(paginatedRecordsArray);
 
-      // create footer to hold tools
-      data.$footerRow = this.find('tfoot');
-
-      if ( data.$footerRow.length === 0 ) {
-        var $footer = $('<tfoot>');
-        data.$footerRow = $footer;
-      }
-
       // create tools if they don't exist already
       if ( !data.$paginationToolsContainer ) {
         methods.generatePaginationTools.call(this);

--- a/timbles.js
+++ b/timbles.js
@@ -401,24 +401,20 @@
       var min = 1;
       var max = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
 
+      function toggleButtons(disabled, buttons) {
+        $.each(buttons, function() {
+          var classToggler = (disabled) ? this.addClass : this.removeClass;
+          classToggler(classes.disabled);
+          this.attr('disabled', disabled);
+        });
+      }
       // set buttons inactive if appropriate
-      if ( data.pagination.currentPage === min ) {
-        data.$linkFirstPage.attr('disabled', true).addClass(classes.disabled);
-        data.$linkPrevPage.attr('disabled', true).addClass(classes.disabled);
-      }
-      else {
-        data.$linkFirstPage.attr('disabled', false).removeClass(classes.disabled);
-        data.$linkPrevPage.attr('disabled', false).removeClass(classes.disabled);
-      }
-
-      if ( data.pagination.currentPage === max ) {
-        data.$linkLastPage.attr('disabled', true).addClass(classes.disabled);
-        data.$linkNextPage.attr('disabled', true).addClass(classes.disabled);
-      }
-      else {
-        data.$linkLastPage.attr('disabled', false).removeClass(classes.disabled);
-        data.$linkNextPage.attr('disabled', false).removeClass(classes.disabled);
-      }
+      toggleButtons(
+        data.pagination.currentPage === min,
+        [data.$linkFirstPage, data.$linkPrevPage]);
+      toggleButtons(
+        data.pagination.currentPage === max,
+        [data.$linkLastPage, data.$linkNextPage]);
 
       // update page number tracker
       data.$pointerThisPage.text(data.pagination.currentPage);

--- a/timbles.js
+++ b/timbles.js
@@ -93,7 +93,6 @@
     setupExistingTable : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       // for each header cell, store its column number
       var $headerRow = data.$headerRow = $this.find('thead tr').eq(0)
@@ -109,7 +108,6 @@
     generateTableFromJson : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       $this.append('<thead><tr class="' + classes.headerRow + '"></tr></thead>');
       data.$headerRow = $this.find('tr.' + classes.headerRow);
@@ -152,7 +150,6 @@
     generateRowsFromData : function(rowData, columnConfig, thisTable) {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       $.each(rowData, function(index, row) {
         var $currentRow = $('<tr>');
@@ -170,7 +167,6 @@
     enableFeaturesSetup : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
       data.$records = this.find('tbody tr');
 
      // if sorting set to true, allow sorting
@@ -193,7 +189,6 @@
     enableSorting : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       // bind sorting to header cells
       $this.find('th').not('.no-sort').on('click', methods.sortColumnEvent.bind($this));
@@ -216,7 +211,6 @@
     sortColumnEvent : function(event, order) {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       // determine order and update header sort classes
       var $sortHeader = $(event.target);
@@ -277,7 +271,7 @@
       var $this = $(this);
       var data = $this.data(pluginName);
       // don't paginate if there are no records
-      if (!data || !data.$records || data.$records.length === 0 ) { return; }
+      if (!data.$records || data.$records.length === 0 ) { return; }
 
       data.pagination.recordsPerPage = count;
       var paginatedRecordsArray = [];
@@ -314,7 +308,6 @@
     generatePaginationTools : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       // create pagination container and place after table
       data.$paginationToolsContainer = $('<div class="' + classes.paginationToolsContainer + '">');
@@ -347,7 +340,6 @@
     generatePaginationNavArrows : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       var thisPage = 1;
       var lastPage = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
@@ -399,7 +391,6 @@
     generatePaginationNavRowCountChoice : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       var optionCount = data.pagination.nav.rowCountChoice.length;
       var arrayOfChoices = [];
@@ -429,7 +420,6 @@
     updatePaginationTools : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       var min = 1;
       var max = Math.ceil(data.$records.length / data.pagination.recordsPerPage);
@@ -461,7 +451,6 @@
     goToPage : function(page) {
       var $this = $(this);
       var data = $this.data(pluginName);
-      if (!data) { return; }
 
       // check for valid page number
       var pageCount = Math.ceil(data.$records.length / data.pagination.recordsPerPage);

--- a/timbles.js
+++ b/timbles.js
@@ -48,7 +48,6 @@
         var $this = $(this).addClass(pluginName);
         var options = $.extend({}, defaults, opts);
         var data = {
-          $this : $this,
           dataConfig: methods.parseDataConfig(options.dataConfig),
           sorting: options.sorting,
           pagination: options.pagination,
@@ -61,9 +60,8 @@
         }
         else {
           // set up existing html table
-          data.$allRows = $this.find('tr');
           data.$headerRow = $this.find('thead tr').eq(0).addClass(classes.headerRow);
-          data.$records = data.$allRows.not('.' + classes.headerRow);
+          data.$records = $this.find('tr').not('.' + classes.headerRow);
 
           // save all this great new data wowowow
           $this.data(pluginName, data);
@@ -171,9 +169,8 @@
         $currentRow.appendTo(thisTable);
       });
 
-      data.$allRows = $this.find('tr');
       data.$headerRow = $this.find('thead tr').eq(0).addClass(classes.headerRow);
-      data.$records = data.$allRows.not('.' + classes.headerRow);
+      data.$records = $this.find('tr').not('.' + classes.headerRow);
 
       $this.data(pluginName, data);
     },
@@ -276,8 +273,7 @@
 
       $(tableBody).appendTo($this);
 
-      data.$allRows = $this.find('tr');
-      data.$records = data.$allRows.not('.' + classes.headerRow);
+      data.$records = $this.find('tr').not('.' + classes.headerRow);
       $this.data(pluginName, data);
 
       // if table was paginated, reenable

--- a/timbles.js
+++ b/timbles.js
@@ -397,34 +397,21 @@
 
     goToPage : function(page) {
       var data = this.data(pluginName);
+      var newFirstRowNum = (page - 1) * data.pagination.recordsPerPage;
+      var newLastRowNum = Math.min(
+        newFirstRowNum + data.pagination.recordsPerPage,
+        data.$records.length);
 
       // check for valid page number
       if ( page < 1 || page > data.pagination.lastPage ) {
         return;
       }
 
-      // move to next page
+      // update page number and display page's rows
       data.pagination.currentPage = page;
-
-      this.find('tr').not('.'+classes.headerRow).remove();
-
-      var paginatedRecordsArray = [];
-      var newFirstRowNum = (page - 1) * (data.pagination.recordsPerPage) + 1,
-          newLastRowNum = page * data.pagination.recordsPerPage;
-
-      if ( newLastRowNum > data.$records.length ) {
-        newLastRowNum = data.$records.length;
-      }
-
-      // get new page's records
-      for ( var i = newFirstRowNum - 1; i < newLastRowNum; i++ ) {
-        if ( data.$records[i] ) {
-          paginatedRecordsArray.push(data.$records[i]);
-        }
-      }
-
-      // add rows to table
-      this.find('tbody').append(paginatedRecordsArray);
+      data.$records.remove();
+      this.find('tbody').append(
+        data.$records.slice(newFirstRowNum, newLastRowNum));
 
       // update pagination tools
       methods.updatePaginationTools.call(this);

--- a/timbles.js
+++ b/timbles.js
@@ -309,9 +309,6 @@
         // update existing pagination tools
         methods.updatePaginationTools.call($this);
       }
-
-      // save it all
-      $this.data(pluginName, data);
     },
 
     generatePaginationTools : function() {
@@ -322,9 +319,6 @@
       // create pagination container and place after table
       data.$paginationToolsContainer = $('<div class="' + classes.paginationToolsContainer + '">');
       $this.after(data.$paginationToolsContainer);
-
-      // save it all
-      $this.data(pluginName, data);
 
       if ( !data.pagination.nav ) {
         // by default, just show arrow nav
@@ -400,10 +394,6 @@
       data.$paginationToolsContainer.append(data.$paginationNavArrows);
       data.$pointerThisPage = data.$paginationToolsContainer.find('.pointer-this-page');
       data.$pointerLastPage = data.$paginationToolsContainer.find('.pointer-last-page');
-
-      // save it all
-      $this.data(pluginName, data);
-
     },
 
     generatePaginationNavRowCountChoice : function() {
@@ -434,9 +424,6 @@
       });
 
       data.$paginationToolsContainer.append(data.$paginationNavRowCountChoice);
-
-      // save it all
-      $this.data(pluginName, data);
     },
 
     updatePaginationTools : function() {
@@ -507,9 +494,6 @@
 
       // update pagination tools
       methods.updatePaginationTools.call($this);
-
-      // update data
-      $this.data(pluginName, data);
     },
 
   };

--- a/timbles.js
+++ b/timbles.js
@@ -60,12 +60,6 @@
         }
         else {
           // set up existing html table
-          data.$headerRow = $this.find('thead tr').eq(0).addClass(classes.headerRow);
-          data.$records = $this.find('tr').not('.' + classes.headerRow);
-
-          // save all this great new data wowowow
-          $this.data(pluginName, data);
-
           methods.setupExistingTable.call($this);
         }
       });
@@ -102,8 +96,10 @@
       if (!data) { return; }
 
       // for each header cell, store its column number
-      data.$headerRow.find('th').each(function(i){
-        $(this).data('timbles-column-index', i);
+      var $headerRow = data.$headerRow = $this.find('thead tr').eq(0)
+        .addClass(classes.headerRow);
+      $headerRow.find('th').each(function(index) {
+        $(this).data('timbles-column-index', index);
       });
 
       // start enabling any given features
@@ -116,6 +112,7 @@
       if (!data) { return; }
 
       $this.append('<thead><tr class="' + classes.headerRow + '"></tr></thead>');
+      data.$headerRow = $this.find('tr.' + classes.headerRow);
 
       // generate and add cell headers to header row
       $.each(data.dataConfig.columns, function(index, value){
@@ -128,7 +125,7 @@
 
         var $cell = $('<th id="' + value.id + '"' + noSortClassString +'>' + value.label + '</th>');
         $cell.data('timbles-column-index', index);
-        $this.find('tr.' + classes.headerRow).append($cell);
+        data.$headerRow.append($cell);
       });
 
       // generate each row of data from json
@@ -168,17 +165,13 @@
         });
         $currentRow.appendTo(thisTable);
       });
-
-      data.$headerRow = $this.find('thead tr').eq(0).addClass(classes.headerRow);
-      data.$records = $this.find('tr').not('.' + classes.headerRow);
-
-      $this.data(pluginName, data);
     },
 
     enableFeaturesSetup : function() {
       var $this = $(this);
       var data = $this.data(pluginName);
       if (!data) { return; }
+      data.$records = this.find('tbody tr');
 
      // if sorting set to true, allow sorting
       if ( data.sorting ) {
@@ -273,14 +266,10 @@
 
       $(tableBody).appendTo($this);
 
-      data.$records = $this.find('tr').not('.' + classes.headerRow);
-      $this.data(pluginName, data);
-
       // if table was paginated, reenable
       if ( data.pagination ) {
-        data.pagination.currentPage = 1;
-        $this.data(pluginName, data);
-        methods.enablePagination.call($this, data.pagination.recordsPerPage);
+        data.$records = this.find('tbody tr');
+        methods.goToPage.call(this, 1);
       }
     },
 

--- a/timbles.js
+++ b/timbles.js
@@ -177,11 +177,8 @@
     },
 
     enableSorting : function() {
-      var $this = $(this);
-      var data = $this.data(pluginName);
-
-      // bind sorting to header cells
-      $this.find('th').not('.no-sort').on('click', methods.sortColumnEvent.bind($this));
+      this.find('th').not('.no-sort').on(
+        'click', methods.sortColumnEvent.bind(this));
     },
 
     sortColumn : function(key, order) {

--- a/timbles.js
+++ b/timbles.js
@@ -344,30 +344,32 @@
     },
 
     generatePaginationNavRowCountChoice : function() {
+      var pageSizeChangeEvent, pageSizeSelection;
       var data = this.data(pluginName);
 
-      data.$paginationNavRowCountChoice = $('<div>')
+      pageSizeSelection = $('<div>')
         .addClass(classes.paginationNavRowCountChoice)
         .appendTo(data.$paginationToolsContainer);
+
+      pageSizeChangeEvent = function(event) {
+        var $target = $(event.target).addClass(classes.active)
+        $target.siblings().removeClass(classes.active);
+        var pageSize = $target.text();
+
+        if ( pageSize.toLowerCase() === 'all' ) {
+          pageSize = data.$records.length;
+        }
+
+        methods.enablePagination.call(this, parseInt(pageSize));
+      }.bind(this);
 
       $.each(data.pagination.nav.rowCountChoice, function() {
         $('<button>')
           .attr('role', 'button')
           .text(this)
-          .appendTo(data.$paginationNavRowCountChoice);
+          .on('click', pageSizeChangeEvent)
+          .appendTo(pageSizeSelection);
       });
-
-      // event listeners
-      data.$paginationNavRowCountChoice.find('button').click(function(event){
-        var $target = $(event.target).addClass(classes.active)
-        var newRowCount = $target.text();
-        $target.siblings().removeClass(classes.active);
-
-        if ( newRowCount.toLowerCase() === 'all' ) {
-          newRowCount = data.$records.length;
-        }
-        methods.enablePagination.call(this, parseInt(newRowCount));
-      }.bind(this));
     },
 
     updatePaginationTools : function() {

--- a/timbles.js
+++ b/timbles.js
@@ -280,7 +280,6 @@
       if (!data || !data.$records || data.$records.length === 0 ) { return; }
 
       data.pagination.recordsPerPage = count;
-      var $recordsToPaginate = data.$records;
       var paginatedRecordsArray = [];
 
       for ( var i = 0; i < count; i++ ) {
@@ -289,16 +288,10 @@
         }
       }
 
-      // remove records if they exist
-      if ( $recordsToPaginate ) {
-        $recordsToPaginate.remove();
-      }
-
-      // show first page
-      $this.append(paginatedRecordsArray);
-
-      // set current page
+      // show the first page and set page counter
+      data.$records.remove();
       data.pagination.currentPage = 1;
+      $this.append(paginatedRecordsArray);
 
       // create footer to hold tools
       data.$footerRow = $this.find('tfoot');

--- a/timbles.js
+++ b/timbles.js
@@ -457,19 +457,16 @@
     },
   };
 
-  /** module definition */
+  // Install timbles jQuery plugin
   $.fn[pluginName] = function (method) {
-    if ( methods[method] ) {
-      return methods[method].apply(this, Array.prototype.slice.call(arguments, 1));
+    if ( methods.hasOwnProperty(method) ) {
+      var methodArgs = Array.prototype.slice.call(arguments, 1);
+      return methods[method].apply(this, methodArgs);
     }
-    else {
-      if ( typeof method === 'object' || !method ) {
-        return methods.init.apply(this, arguments);
-      }
-      else {
-        $.error('The method ' + method + ' literally does not exist. Good job.');
-      }
+    if ( typeof method === 'object' || !method ) {
+      return methods.init.apply(this, arguments);
     }
+    $.error('The method ' + method + ' literally does not exist. Good job.');
   };
 
 })( jQuery );

--- a/timbles.js
+++ b/timbles.js
@@ -256,26 +256,13 @@
       data.pagination.recordsPerPage = count;
       data.pagination.lastPage = Math.ceil(data.$records.length / count);
 
-      var paginatedRecordsArray = [];
-
-      for ( var i = 0; i < count; i++ ) {
-        if ( data.$records[i] ) {
-          paginatedRecordsArray.push(data.$records[i]);
-        }
-      }
-
-      // show the first page and set page counter
-      data.$records.remove();
-      this.append(paginatedRecordsArray);
-
-      // create tools if they don't exist already
+      // Create tools if they don't exist yet
       if ( !data.$paginationToolsContainer ) {
         methods.generatePaginationTools.call(this);
       }
-      else {
-        // update existing pagination tools
-        methods.updatePaginationTools.call(this);
-      }
+
+      // Actually place records for the first page
+      methods.goToPage.call(this, 1);
     },
 
     generatePaginationTools : function() {

--- a/timbles.js
+++ b/timbles.js
@@ -184,7 +184,7 @@
       }
 
       // if pagination set to true, set pagination
-      if ( data.pagination && data.$records ) {
+      if ( data.pagination ) {
         methods.enablePagination.call($this, data.pagination.recordsPerPage);
       }
 


### PR DESCRIPTION
So here's a massive set of changes to the inner workings of timbles. There's a bit of back and forth in some of the commits so I may squash some together, refactor other bits and stuff, but the outcome should remain largely the same.

What this mainly does:
- Remove duplicate code (like `enablePagination()` including `goToPage(1)` and smaller scale)
- Remove early exits due to improper caller use (error hiding is bad; you shouldn't `.timbles()` on improper selectors, and if you do, you deserve an error)
- Remove code / properties that doesn't do or change anything
- Remove unnecessary jQuerifying of `this` and binding scopes to remove the need for aliasing;
- Creation of HTML elements by attribute manipulation rather than string concats
- Make better use of method chaining to express actions

Very much open for feedback

Happy New Year :fireworks: 
