### PR TITLE
Fix style inconsistencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+indent_style = space
+indent_size = 2
+
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules/
 npm-debug.log

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,6 @@
+{
+  "preset": "jquery",
+  "maxErrors": -1,
+  "validateIndentation": 2,
+  "validateQuoteMarks": { "mark": "'", "escape": true }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,14 @@
+{
+  "boss": true,
+  "curly": true,
+  "eqeqeq": true,
+  "eqnull": true,
+  "expr": true,
+  "immed": true,
+  "noarg": true,
+  "quotmark": "double",
+  "smarttabs": true,
+  "trailing": true,
+  "undef": true,
+  "unused": true
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+
+  // Project configuration.
+  grunt.initConfig({
+    pkg: grunt.file.readJSON('package.json'),
+    jshint: {
+      all: 'timbles.js'
+    },
+    jscs: {
+      src: 'timbles.js',
+      options: {
+        config: '.jscsrc',
+        verbose: true // Create output with rule names
+      }
+    }
+  });
+
+  // Load the JSHint and JSCS plugins.
+  grunt.loadNpmTasks('grunt-contrib-jshint');
+  grunt.loadNpmTasks('grunt-jscs');
+
+  // Default task(s).
+  grunt.registerTask('default', ['jshint', 'jscs']);
+};

--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "seo",
     "jquery-plugin"
   ],
+  "devDependencies": {
+    "grunt": "~0.4.5",
+    "grunt-contrib-jshint": "^0.12.0",
+    "grunt-jscs": "^2"
+  },
   "author": "Jenn Schiffer <jenn@dotbiz.info> (http://jennmoney.biz)",
   "license": "MIT",
   "bugs": {

--- a/timbles.js
+++ b/timbles.js
@@ -42,7 +42,7 @@ var copy = {
 
 var methods = {
 
-  /** initialize timble, er, i mean table **/
+  // Initialize timble, er, i mean table //
   init: function( opts ) {
     return this.each( function() {
       var $this = $( this ).addClass( pluginName );
@@ -55,11 +55,9 @@ var methods = {
       $this.data( pluginName, data );
 
       if ( data.dataConfig ) {
-        // generate table from JSON
         methods.generateTableFromJson.call( $this );
       }
       else {
-        // set up existing html table
         methods.setupExistingTable.call( $this );
       }
     } );
@@ -73,15 +71,18 @@ var methods = {
       $.each( dataConfig.columns, function( index, columnConfig ) {
         if ( columnConfig.hasOwnProperty( 'dataFilter' ) &&
              !columnConfig.hasOwnProperty( 'textTransform' ) ) {
+
           // If a dataFilter is defined (old-style) and no textTransform,
           // use the dataFilter as textTransform
           columnConfig.textTransform = columnConfig.dataFilter;
         }
         else if ( !columnConfig.hasOwnProperty( 'textTransform' ) ) {
+
           // Add a do-nothing textTransform if none is provided
           columnConfig.textTransform = function( obj ) { return obj; };
         }
         if ( !columnConfig.hasOwnProperty( 'valueTransform' ) ) {
+
           // Add a do-nothing valueTransform if none is provided
           columnConfig.valueTransform = function( obj ) { return obj; };
         }
@@ -93,14 +94,14 @@ var methods = {
   setupExistingTable: function() {
     var data = this.data( pluginName );
 
-    // for each header cell, store its column number
+    // For each header cell, store its column number
     var $headerRow = data.$headerRow = this.find( 'thead tr' ).eq( 0 )
       .addClass( classes.headerRow );
     $headerRow.find( 'th' ).each( function( index ) {
       $( this ).data( 'timbles-column-index', index );
     } );
 
-    // start enabling any given features
+    // Start enabling any given features
     methods.enableFeaturesSetup.call( this );
   },
 
@@ -110,7 +111,7 @@ var methods = {
       .addClass( classes.headerRow )
       .appendTo( $( '<thead>' ).appendTo( this ) );
 
-    // generate and add cell headers to header row
+    // Generate and add cell headers to header row
     $.each( data.dataConfig.columns, function( index, value ) {
       $( '<th>' )
         .attr( 'id', value.id )
@@ -121,18 +122,21 @@ var methods = {
     } );
 
     if ( $.isArray( data.dataConfig.data ) ) {
-      // no need for ajax call if data is local array
+
+      // No need for ajax call if data is local array
       methods.generateRowsFromData.call( this, data.dataConfig.data, data.dataConfig.columns );
 
-      // start enabling any given features
+      // Start enabling any given features
       methods.enableFeaturesSetup.call( this );
     }
     else {
-      // get external json file given
+
+      // Get external json file given
       $.getJSON( data.dataConfig.data, function( json ) {
         methods.generateRowsFromData.call( this, json, data.dataConfig.columns );
       }.bind( this ) ).then( function() {
-        // start enabling any given features
+
+        // Start enabling any given features
         methods.enableFeaturesSetup.call( this );
       }.bind( this ) );
     }
@@ -140,9 +144,11 @@ var methods = {
 
   generateRowsFromData: function( rowData, columnConfig ) {
     $.each( rowData, function( index, row ) {
+
       // Add rows to the current table
       var $newRow = $( '<tr>' ).appendTo( this );
       $.each( columnConfig, function( index, column ) {
+
         // Add cells to the current row
         var cellValue = row[ column.id ];
         $( '<td>' )
@@ -176,6 +182,7 @@ var methods = {
   },
 
   sortColumn: function( key, order ) {
+
     // Sort a column identified by its key in a given order
     // If `key` is numeric, it is treated as the column index to sort
     // If `order` is not given, this will do the same as clicking the header
@@ -191,7 +198,7 @@ var methods = {
   sortColumnEvent: function( event, order ) {
     var data = this.data( pluginName );
 
-    // determine order and update header sort classes
+    // Determine order and update header sort classes
     var $sortHeader = $( event.target );
     var sortColumn = $sortHeader.data( 'timbles-column-index' );
 
@@ -203,7 +210,7 @@ var methods = {
       .removeClass( classes.sortDESC );
     $sortHeader.addClass( ( order === 'asc' ) ? classes.sortASC : classes.sortDESC );
 
-    // determine column values to actually sort by
+    // Determine column values to actually sort by
     var sortMap = data.$records.map( function() {
       var cell = this.children[ sortColumn ];
       var dataValue = cell.getAttribute( 'data-value' );
@@ -219,7 +226,7 @@ var methods = {
       };
     } );
 
-    // sort the mapping by the extract column values
+    // Sort the mapping by the extract column values
     sortMap.sort( function( a, b ) {
       if ( a.value > b.value ) {
         return ( order === 'asc' ) ? 1 : -1;
@@ -230,7 +237,7 @@ var methods = {
       return 0;
     } );
 
-    // use sortMap to shuffle table rows to the correct order
+    // Use sortMap to shuffle table rows to the correct order
     // work on detached DOM for improved performance on large tables
     var tableBody = this.find( 'tbody' ).detach().get( 0 );
     sortMap.each( function() {
@@ -239,7 +246,7 @@ var methods = {
 
     $( tableBody ).appendTo( this );
 
-    // if table was paginated, reenable
+    // If table was paginated, reenable
     if ( data.pagination ) {
       data.$records = this.find( 'tbody tr' );
       methods.goToPage.call( this, 1 );
@@ -248,7 +255,8 @@ var methods = {
 
   enablePagination: function( count ) {
     var data = this.data( pluginName );
-    // don't paginate if there are no records
+
+    // If there are no records, abandon pagination
     if ( !data.$records || data.$records.length === 0 ) { return; }
 
     // Update pagination page size and count
@@ -273,26 +281,22 @@ var methods = {
       .insertAfter( this );
 
     if ( !data.pagination.nav ) {
-      // by default, just show arrow nav
+
+      // If no pagination is configured, default to showing arrows only
       methods.generatePaginationNavArrows.call( this );
     }
     else {
-      // iterate through nav object and add tools to footer
       for ( var navObject in data.pagination.nav ) {
         switch ( navObject ) {
-          // arrows
           case "arrows":
             methods.generatePaginationNavArrows.call( this );
             break;
-          // row count choice
           case "rowCountChoice":
             methods.generatePaginationNavRowCountChoice.call( this );
             break;
         }
       }
     }
-
-    // update tools
     methods.updatePaginationTools.call( this );
   },
 
@@ -321,7 +325,7 @@ var methods = {
       .append( data.$linkLastPage )
       .appendTo( data.$paginationToolsContainer );
 
-    // event listeners
+    // Register event listeners
     data.$linkFirstPage.click( function() {
       methods.goToPage.call( this, 1 );
     }.bind( this ) );
@@ -382,7 +386,8 @@ var methods = {
         this.attr( 'disabled', disabled );
       } );
     }
-    // set buttons inactive if appropriate
+
+    // Set buttons inactive if appropriate
     toggleButtons(
       data.pagination.currentPage === 1,
       [ data.$linkFirstPage, data.$linkPrevPage ] );
@@ -390,7 +395,7 @@ var methods = {
       data.pagination.currentPage === data.pagination.lastPage,
       [ data.$linkLastPage, data.$linkNextPage ] );
 
-    // update page number tracker
+    // Update page number tracker
     data.$pointerThisPage.text( data.pagination.currentPage );
     data.$pointerLastPage.text( data.pagination.lastPage );
   },
@@ -402,18 +407,18 @@ var methods = {
       newFirstRowNum + data.pagination.recordsPerPage,
       data.$records.length );
 
-    // check for valid page number
+    // Check for valid page number
     if ( page < 1 || page > data.pagination.lastPage ) {
       return;
     }
 
-    // update page number and display page's rows
+    // Update page number and display page's rows
     data.pagination.currentPage = page;
     data.$records.remove();
     this.find( 'tbody' ).append(
       data.$records.slice( newFirstRowNum, newLastRowNum ) );
 
-    // update pagination tools
+    // Update pagination tools
     methods.updatePaginationTools.call( this );
   },
 };

--- a/timbles.js
+++ b/timbles.js
@@ -14,36 +14,36 @@
 var pluginName = 'timbles';
 
 var defaults = {
-  sortKey : null,
-  sortOrder : null,
+  sortKey: null,
+  sortOrder: null,
 };
 
 var classes = {
-  disabled : 'disabled',
-  active : 'active',
-  headerRow : 'header-row',
-  label : 'label',
-  sortASC : 'sorted-asc',
-  sortDESC : 'sorted-desc',
-  noSort : 'no-sort',
-  paginationToolsContainer : 'pagination',
-  paginationNavArrows : 'nav-arrows',
-  paginationNavRowCountChoice : 'row-count-choice'
+  disabled: 'disabled',
+  active: 'active',
+  headerRow: 'header-row',
+  label: 'label',
+  sortASC: 'sorted-asc',
+  sortDESC: 'sorted-desc',
+  noSort: 'no-sort',
+  paginationToolsContainer: 'pagination',
+  paginationNavArrows: 'nav-arrows',
+  paginationNavRowCountChoice: 'row-count-choice'
 };
 
 var copy = {
-  firstPageArrow : ' << ',
-  prevPageArrow : ' < ',
-  nextPageArrow : ' > ',
-  lastPageArrow : ' >> ',
-  page : 'page',
-  of : 'of'
+  firstPageArrow: ' << ',
+  prevPageArrow: ' < ',
+  nextPageArrow: ' > ',
+  lastPageArrow: ' >> ',
+  page: 'page',
+  of: 'of'
 };
 
 var methods = {
 
   /** initialize timble, er, i mean table **/
-  init : function(opts) {
+  init: function(opts) {
     return this.each(function() {
       var $this = $(this).addClass(pluginName);
       var options = $.extend({}, defaults, opts);
@@ -65,7 +65,7 @@ var methods = {
     });
   },
 
-  parseDataConfig : function(dataConfig) {
+  parseDataConfig: function(dataConfig) {
     if (!(dataConfig instanceof Object)) {
       return dataConfig;
     }
@@ -90,7 +90,7 @@ var methods = {
     return dataConfig;
   },
 
-  setupExistingTable : function() {
+  setupExistingTable: function() {
     var data = this.data(pluginName);
 
     // for each header cell, store its column number
@@ -104,7 +104,7 @@ var methods = {
     methods.enableFeaturesSetup.call(this);
   },
 
-  generateTableFromJson : function() {
+  generateTableFromJson: function() {
     var data = this.data(pluginName);
     var $headerRow = data.$headerRow = $('<tr>')
       .addClass(classes.headerRow)
@@ -138,7 +138,7 @@ var methods = {
     }
   },
 
-  generateRowsFromData : function(rowData, columnConfig) {
+  generateRowsFromData: function(rowData, columnConfig) {
     $.each(rowData, function(index, row) {
       // Add rows to the current table
       var $newRow = $('<tr>').appendTo(this);
@@ -153,7 +153,7 @@ var methods = {
     }.bind(this));
   },
 
-  enableFeaturesSetup : function() {
+  enableFeaturesSetup: function() {
     var data = this.data(pluginName);
     data.$records = this.find('tbody tr');
 
@@ -170,12 +170,12 @@ var methods = {
     }
   },
 
-  enableSorting : function() {
+  enableSorting: function() {
     this.find('th').not('.no-sort').on(
       'click', methods.sortColumnEvent.bind(this));
   },
 
-  sortColumn : function(key, order) {
+  sortColumn: function(key, order) {
     // Sort a column identified by its key in a given order
     // If `key` is numeric, it is treated as the column index to sort
     // If `order` is not given, this will do the same as clicking the header
@@ -188,7 +188,7 @@ var methods = {
     }
   },
 
-  sortColumnEvent : function(event, order) {
+  sortColumnEvent: function(event, order) {
     var data = this.data(pluginName);
 
     // determine order and update header sort classes
@@ -246,7 +246,7 @@ var methods = {
     }
   },
 
-  enablePagination : function(count) {
+  enablePagination: function(count) {
     var data = this.data(pluginName);
     // don't paginate if there are no records
     if (!data.$records || data.$records.length === 0 ) { return; }
@@ -265,7 +265,7 @@ var methods = {
     methods.goToPage.call(this, 1);
   },
 
-  generatePaginationTools : function() {
+  generatePaginationTools: function() {
     var data = this.data(pluginName);
 
     data.$paginationToolsContainer = $('<div>')
@@ -296,7 +296,7 @@ var methods = {
     methods.updatePaginationTools.call(this);
   },
 
-  generatePaginationNavArrows : function() {
+  generatePaginationNavArrows: function() {
     var data = this.data(pluginName);
 
     data.$linkFirstPage = $('<button role="button">').text(copy.firstPageArrow);
@@ -343,7 +343,7 @@ var methods = {
     }.bind(this));
   },
 
-  generatePaginationNavRowCountChoice : function() {
+  generatePaginationNavRowCountChoice: function() {
     var pageSizeChangeEvent, pageSizeSelection;
     var data = this.data(pluginName);
 
@@ -372,7 +372,7 @@ var methods = {
     });
   },
 
-  updatePaginationTools : function() {
+  updatePaginationTools: function() {
     var data = this.data(pluginName);
 
     function toggleButtons(disabled, buttons) {
@@ -395,7 +395,7 @@ var methods = {
     data.$pointerLastPage.text(data.pagination.lastPage);
   },
 
-  goToPage : function(page) {
+  goToPage: function(page) {
     var data = this.data(pluginName);
     var newFirstRowNum = (page - 1) * data.pagination.recordsPerPage;
     var newLastRowNum = Math.min(

--- a/timbles.js
+++ b/timbles.js
@@ -43,364 +43,364 @@ var copy = {
 var methods = {
 
   /** initialize timble, er, i mean table **/
-  init: function(opts) {
-    return this.each(function() {
-      var $this = $(this).addClass(pluginName);
-      var options = $.extend({}, defaults, opts);
+  init: function( opts ) {
+    return this.each( function() {
+      var $this = $( this ).addClass( pluginName );
+      var options = $.extend( {}, defaults, opts );
       var data = {
-        dataConfig: methods.parseDataConfig(options.dataConfig),
+        dataConfig: methods.parseDataConfig( options.dataConfig ),
         sorting: options.sorting,
         pagination: options.pagination,
       };
-      $this.data(pluginName, data);
+      $this.data( pluginName, data );
 
       if ( data.dataConfig ) {
         // generate table from JSON
-        methods.generateTableFromJson.call($this);
+        methods.generateTableFromJson.call( $this );
       }
       else {
         // set up existing html table
-        methods.setupExistingTable.call($this);
+        methods.setupExistingTable.call( $this );
       }
-    });
+    } );
   },
 
-  parseDataConfig: function(dataConfig) {
-    if (!(dataConfig instanceof Object)) {
+  parseDataConfig: function( dataConfig ) {
+    if ( !( dataConfig instanceof Object ) ) {
       return dataConfig;
     }
-    else if (dataConfig.hasOwnProperty('columns')) {
-      $.each(dataConfig.columns, function(index, columnConfig) {
-        if (columnConfig.hasOwnProperty('dataFilter') &&
-            !columnConfig.hasOwnProperty('textTransform')) {
+    else if ( dataConfig.hasOwnProperty( 'columns' ) ) {
+      $.each( dataConfig.columns, function( index, columnConfig ) {
+        if ( columnConfig.hasOwnProperty( 'dataFilter' ) &&
+             !columnConfig.hasOwnProperty( 'textTransform' ) ) {
           // If a dataFilter is defined (old-style) and no textTransform,
           // use the dataFilter as textTransform
           columnConfig.textTransform = columnConfig.dataFilter;
         }
-        else if (!columnConfig.hasOwnProperty('textTransform')) {
+        else if ( !columnConfig.hasOwnProperty( 'textTransform' ) ) {
           // Add a do-nothing textTransform if none is provided
-          columnConfig.textTransform = function (obj) {return obj;};
+          columnConfig.textTransform = function( obj ) { return obj; };
         }
-        if (!columnConfig.hasOwnProperty('valueTransform')) {
+        if ( !columnConfig.hasOwnProperty( 'valueTransform' ) ) {
           // Add a do-nothing valueTransform if none is provided
-          columnConfig.valueTransform = function (obj) {return obj;};
+          columnConfig.valueTransform = function( obj ) { return obj; };
         }
-      });
+      } );
     }
     return dataConfig;
   },
 
   setupExistingTable: function() {
-    var data = this.data(pluginName);
+    var data = this.data( pluginName );
 
     // for each header cell, store its column number
-    var $headerRow = data.$headerRow = this.find('thead tr').eq(0)
-      .addClass(classes.headerRow);
-    $headerRow.find('th').each(function(index) {
-      $(this).data('timbles-column-index', index);
-    });
+    var $headerRow = data.$headerRow = this.find( 'thead tr' ).eq( 0 )
+      .addClass( classes.headerRow );
+    $headerRow.find( 'th' ).each( function( index ) {
+      $( this ).data( 'timbles-column-index', index );
+    } );
 
     // start enabling any given features
-    methods.enableFeaturesSetup.call(this);
+    methods.enableFeaturesSetup.call( this );
   },
 
   generateTableFromJson: function() {
-    var data = this.data(pluginName);
-    var $headerRow = data.$headerRow = $('<tr>')
-      .addClass(classes.headerRow)
-      .appendTo($('<thead>').appendTo(this));
+    var data = this.data( pluginName );
+    var $headerRow = data.$headerRow = $( '<tr>' )
+      .addClass( classes.headerRow )
+      .appendTo( $( '<thead>' ).appendTo( this ) );
 
     // generate and add cell headers to header row
-    $.each(data.dataConfig.columns, function(index, value) {
-      $('<th>')
-        .attr('id', value.id)
-        .addClass(value.noSorting ? classes.noSort : null)
-        .data('timbles-column-index', index)
-        .text(value.label)
-        .appendTo($headerRow);
-    });
+    $.each( data.dataConfig.columns, function( index, value ) {
+      $( '<th>' )
+        .attr( 'id', value.id )
+        .addClass( value.noSorting ? classes.noSort : null )
+        .data( 'timbles-column-index', index )
+        .text( value.label )
+        .appendTo( $headerRow );
+    } );
 
-    if ($.isArray(data.dataConfig.data)) {
+    if ( $.isArray( data.dataConfig.data ) ) {
       // no need for ajax call if data is local array
-      methods.generateRowsFromData.call(this, data.dataConfig.data, data.dataConfig.columns);
+      methods.generateRowsFromData.call( this, data.dataConfig.data, data.dataConfig.columns );
 
       // start enabling any given features
-      methods.enableFeaturesSetup.call(this);
+      methods.enableFeaturesSetup.call( this );
     }
     else {
       // get external json file given
-      $.getJSON( data.dataConfig.data, function(json) {
-        methods.generateRowsFromData.call(this, json, data.dataConfig.columns);
-      }.bind(this)).then(function(){
+      $.getJSON( data.dataConfig.data, function( json ) {
+        methods.generateRowsFromData.call( this, json, data.dataConfig.columns );
+      }.bind( this ) ).then( function() {
         // start enabling any given features
-        methods.enableFeaturesSetup.call(this);
-      }.bind(this));
+        methods.enableFeaturesSetup.call( this );
+      }.bind( this ) );
     }
   },
 
-  generateRowsFromData: function(rowData, columnConfig) {
-    $.each(rowData, function(index, row) {
+  generateRowsFromData: function( rowData, columnConfig ) {
+    $.each( rowData, function( index, row ) {
       // Add rows to the current table
-      var $newRow = $('<tr>').appendTo(this);
-      $.each(columnConfig, function(index, column) {
+      var $newRow = $( '<tr>' ).appendTo( this );
+      $.each( columnConfig, function( index, column ) {
         // Add cells to the current row
-        var cellValue = row[column.id];
-        $('<td>')
-          .attr('data-value', column.valueTransform(cellValue))
-          .text(column.textTransform(cellValue))
-          .appendTo(this);
-      }.bind($newRow));
-    }.bind(this));
+        var cellValue = row[ column.id ];
+        $( '<td>' )
+          .attr( 'data-value', column.valueTransform( cellValue ) )
+          .text( column.textTransform( cellValue ) )
+          .appendTo( this );
+      }.bind( $newRow ) );
+    }.bind( this ) );
   },
 
   enableFeaturesSetup: function() {
-    var data = this.data(pluginName);
-    data.$records = this.find('tbody tr');
+    var data = this.data( pluginName );
+    data.$records = this.find( 'tbody tr' );
 
     if ( data.sorting ) {
-      methods.enableSorting.call(this);
+      methods.enableSorting.call( this );
 
       if ( data.sorting.keyId ) {
-        methods.sortColumn.call(this, data.sorting.keyId, data.sorting.order);
+        methods.sortColumn.call( this, data.sorting.keyId, data.sorting.order );
       }
     }
 
     if ( data.pagination ) {
-      methods.enablePagination.call(this, data.pagination.recordsPerPage);
+      methods.enablePagination.call( this, data.pagination.recordsPerPage );
     }
   },
 
   enableSorting: function() {
-    this.find('th').not('.no-sort').on(
-      'click', methods.sortColumnEvent.bind(this));
+    this.find( 'th' ).not( '.no-sort' ).on(
+      'click', methods.sortColumnEvent.bind( this ) );
   },
 
-  sortColumn: function(key, order) {
+  sortColumn: function( key, order ) {
     // Sort a column identified by its key in a given order
     // If `key` is numeric, it is treated as the column index to sort
     // If `order` is not given, this will do the same as clicking the header
-    if (typeof key === "number") {
-      var data = this.data(pluginName);
-      data.$headerRow.find('th').eq(key).trigger('click', order);
+    if ( typeof key === "number" ) {
+      var data = this.data( pluginName );
+      data.$headerRow.find( 'th' ).eq( key ).trigger( 'click', order );
     }
     else {
-      this.find('#' + key).trigger('click', order);
+      this.find( '#' + key ).trigger( 'click', order );
     }
   },
 
-  sortColumnEvent: function(event, order) {
-    var data = this.data(pluginName);
+  sortColumnEvent: function( event, order ) {
+    var data = this.data( pluginName );
 
     // determine order and update header sort classes
-    var $sortHeader = $(event.target);
-    var sortColumn = $sortHeader.data('timbles-column-index');
+    var $sortHeader = $( event.target );
+    var sortColumn = $sortHeader.data( 'timbles-column-index' );
 
     if ( !order ) {
-      order = $sortHeader.hasClass(classes.sortASC) ? 'desc' : 'asc';
+      order = $sortHeader.hasClass( classes.sortASC ) ? 'desc' : 'asc';
     }
-    data.$headerRow.find('th')
-      .removeClass(classes.sortASC)
-      .removeClass(classes.sortDESC);
-    $sortHeader.addClass((order === 'asc') ? classes.sortASC : classes.sortDESC);
+    data.$headerRow.find( 'th' )
+      .removeClass( classes.sortASC )
+      .removeClass( classes.sortDESC );
+    $sortHeader.addClass( ( order === 'asc' ) ? classes.sortASC : classes.sortDESC );
 
     // determine column values to actually sort by
-    var sortMap = data.$records.map(function() {
-      var cell = this.children[sortColumn];
-      var dataValue = cell.getAttribute('data-value');
-      if (dataValue === null) {
+    var sortMap = data.$records.map( function() {
+      var cell = this.children[ sortColumn ];
+      var dataValue = cell.getAttribute( 'data-value' );
+      if ( dataValue === null ) {
         dataValue = cell.textContent || cell.innerText;
       }
-      else if (parseFloat(dataValue).toString() === dataValue) {
-        dataValue = parseFloat(dataValue);
+      else if ( parseFloat( dataValue ).toString() === dataValue ) {
+        dataValue = parseFloat( dataValue );
       }
       return {
         node: this,
         value: dataValue
       };
-    });
+    } );
 
     // sort the mapping by the extract column values
-    sortMap.sort(function(a, b) {
-      if (a.value > b.value) {
-        return (order === 'asc') ? 1 : -1;
+    sortMap.sort( function( a, b ) {
+      if ( a.value > b.value ) {
+        return ( order === 'asc' ) ? 1 : -1;
       }
-      if (a.value < b.value) {
-        return (order === 'asc') ? -1 : 1;
+      if ( a.value < b.value ) {
+        return ( order === 'asc' ) ? -1 : 1;
       }
       return 0;
-    });
+    } );
 
     // use sortMap to shuffle table rows to the correct order
     // work on detached DOM for improved performance on large tables
-    var tableBody = this.find('tbody').detach().get(0);
-    sortMap.each(function() {
-      tableBody.appendChild(this.node);
-    });
+    var tableBody = this.find( 'tbody' ).detach().get( 0 );
+    sortMap.each( function() {
+      tableBody.appendChild( this.node );
+    } );
 
-    $(tableBody).appendTo(this);
+    $( tableBody ).appendTo( this );
 
     // if table was paginated, reenable
     if ( data.pagination ) {
-      data.$records = this.find('tbody tr');
-      methods.goToPage.call(this, 1);
+      data.$records = this.find( 'tbody tr' );
+      methods.goToPage.call( this, 1 );
     }
   },
 
-  enablePagination: function(count) {
-    var data = this.data(pluginName);
+  enablePagination: function( count ) {
+    var data = this.data( pluginName );
     // don't paginate if there are no records
-    if (!data.$records || data.$records.length === 0 ) { return; }
+    if ( !data.$records || data.$records.length === 0 ) { return; }
 
     // Update pagination page size and count
     data.pagination.currentPage = 1;
     data.pagination.recordsPerPage = count;
-    data.pagination.lastPage = Math.ceil(data.$records.length / count);
+    data.pagination.lastPage = Math.ceil( data.$records.length / count );
 
     // Create tools if they don't exist yet
     if ( !data.$paginationToolsContainer ) {
-      methods.generatePaginationTools.call(this);
+      methods.generatePaginationTools.call( this );
     }
 
     // Actually place records for the first page
-    methods.goToPage.call(this, 1);
+    methods.goToPage.call( this, 1 );
   },
 
   generatePaginationTools: function() {
-    var data = this.data(pluginName);
+    var data = this.data( pluginName );
 
-    data.$paginationToolsContainer = $('<div>')
-      .addClass(classes.paginationToolsContainer)
-      .insertAfter(this);
+    data.$paginationToolsContainer = $( '<div>' )
+      .addClass( classes.paginationToolsContainer )
+      .insertAfter( this );
 
     if ( !data.pagination.nav ) {
       // by default, just show arrow nav
-      methods.generatePaginationNavArrows.call(this);
+      methods.generatePaginationNavArrows.call( this );
     }
     else {
       // iterate through nav object and add tools to footer
       for ( var navObject in data.pagination.nav ) {
-        switch (navObject) {
+        switch ( navObject ) {
           // arrows
           case "arrows":
-            methods.generatePaginationNavArrows.call(this);
+            methods.generatePaginationNavArrows.call( this );
             break;
           // row count choice
           case "rowCountChoice":
-            methods.generatePaginationNavRowCountChoice.call(this);
+            methods.generatePaginationNavRowCountChoice.call( this );
             break;
         }
       }
     }
 
     // update tools
-    methods.updatePaginationTools.call(this);
+    methods.updatePaginationTools.call( this );
   },
 
   generatePaginationNavArrows: function() {
-    var data = this.data(pluginName);
+    var data = this.data( pluginName );
 
-    data.$linkFirstPage = $('<button role="button">').text(copy.firstPageArrow);
-    data.$linkPrevPage = $('<button role="button">').text(copy.prevPageArrow);
-    data.$linkNextPage = $('<button role="button">').text(copy.nextPageArrow);
-    data.$linkLastPage = $('<button role="button">').text(copy.lastPageArrow);
-    var $pageNumberTracker = $('<span>')
-      .addClass('page-number-tracker')
-      .text(copy.page + ' ')
-      .append($('<span>').addClass('pointer-this-page').text(data.pagination.currentPage))
-      .append(' ' + copy.of + ' ')
-      .append($('<span>').addClass('pointer-last-page').text(data.pagination.lastPage));
+    data.$linkFirstPage = $( '<button role="button">' ).text( copy.firstPageArrow );
+    data.$linkPrevPage = $( '<button role="button">' ).text( copy.prevPageArrow );
+    data.$linkNextPage = $( '<button role="button">' ).text( copy.nextPageArrow );
+    data.$linkLastPage = $( '<button role="button">' ).text( copy.lastPageArrow );
+    var $pageNumberTracker = $( '<span>' )
+      .addClass( 'page-number-tracker' )
+      .text( copy.page + ' ' )
+      .append( $( '<span>' ).addClass( 'pointer-this-page' ).text( data.pagination.currentPage ) )
+      .append( ' ' + copy.of + ' ' )
+      .append( $( '<span>' ).addClass( 'pointer-last-page' ).text( data.pagination.lastPage ) );
 
-    data.$pointerThisPage = $pageNumberTracker.find('.pointer-this-page');
-    data.$pointerLastPage = $pageNumberTracker.find('.pointer-last-page');
-    $('<div>')
-      .addClass(classes.paginationNavArrows)
-      .append(data.$linkFirstPage)
-      .append(data.$linkPrevPage)
-      .append($pageNumberTracker)
-      .append(data.$linkNextPage)
-      .append(data.$linkLastPage)
-      .appendTo(data.$paginationToolsContainer);
+    data.$pointerThisPage = $pageNumberTracker.find( '.pointer-this-page' );
+    data.$pointerLastPage = $pageNumberTracker.find( '.pointer-last-page' );
+    $( '<div>' )
+      .addClass( classes.paginationNavArrows )
+      .append( data.$linkFirstPage )
+      .append( data.$linkPrevPage )
+      .append( $pageNumberTracker )
+      .append( data.$linkNextPage )
+      .append( data.$linkLastPage )
+      .appendTo( data.$paginationToolsContainer );
 
     // event listeners
-    data.$linkFirstPage.click(function(){
-      methods.goToPage.call(this, 1);
-    }.bind(this));
+    data.$linkFirstPage.click( function() {
+      methods.goToPage.call( this, 1 );
+    }.bind( this ) );
 
-    data.$linkPrevPage.click(function(){
-      if ( data.pagination.currentPage > 1) {
-        methods.goToPage.call(this, data.pagination.currentPage - 1);
+    data.$linkPrevPage.click( function() {
+      if ( data.pagination.currentPage > 1 ) {
+        methods.goToPage.call( this, data.pagination.currentPage - 1 );
       }
-    }.bind(this));
+    }.bind( this ) );
 
-    data.$linkNextPage.click(function(){
+    data.$linkNextPage.click( function() {
       if ( data.pagination.currentPage < data.pagination.lastPage ) {
-        methods.goToPage.call(this, data.pagination.currentPage + 1);
+        methods.goToPage.call( this, data.pagination.currentPage + 1 );
       }
-    }.bind(this));
+    }.bind( this ) );
 
-    data.$linkLastPage.click(function(){
-      methods.goToPage.call(this, data.pagination.lastPage);
-    }.bind(this));
+    data.$linkLastPage.click( function() {
+      methods.goToPage.call( this, data.pagination.lastPage );
+    }.bind( this ) );
   },
 
   generatePaginationNavRowCountChoice: function() {
     var pageSizeChangeEvent, pageSizeSelection;
-    var data = this.data(pluginName);
+    var data = this.data( pluginName );
 
-    pageSizeSelection = $('<div>')
-      .addClass(classes.paginationNavRowCountChoice)
-      .appendTo(data.$paginationToolsContainer);
+    pageSizeSelection = $( '<div>' )
+      .addClass( classes.paginationNavRowCountChoice )
+      .appendTo( data.$paginationToolsContainer );
 
-    pageSizeChangeEvent = function(event) {
-      var $target = $(event.target).addClass(classes.active)
-      $target.siblings().removeClass(classes.active);
+    pageSizeChangeEvent = function( event ) {
+      var $target = $( event.target ).addClass( classes.active )
+      $target.siblings().removeClass( classes.active );
       var pageSize = $target.text();
 
       if ( pageSize.toLowerCase() === 'all' ) {
         pageSize = data.$records.length;
       }
 
-      methods.enablePagination.call(this, parseInt(pageSize));
-    }.bind(this);
+      methods.enablePagination.call( this, parseInt( pageSize ) );
+    }.bind( this );
 
-    $.each(data.pagination.nav.rowCountChoice, function() {
-      $('<button>')
-        .attr('role', 'button')
-        .text(this)
-        .on('click', pageSizeChangeEvent)
-        .appendTo(pageSizeSelection);
-    });
+    $.each( data.pagination.nav.rowCountChoice, function() {
+      $( '<button>' )
+        .attr( 'role', 'button' )
+        .text( this )
+        .on( 'click', pageSizeChangeEvent )
+        .appendTo( pageSizeSelection );
+    } );
   },
 
   updatePaginationTools: function() {
-    var data = this.data(pluginName);
+    var data = this.data( pluginName );
 
-    function toggleButtons(disabled, buttons) {
-      $.each(buttons, function() {
-        var classToggler = (disabled) ? this.addClass : this.removeClass;
-        classToggler(classes.disabled);
-        this.attr('disabled', disabled);
-      });
+    function toggleButtons( disabled, buttons ) {
+      $.each( buttons, function() {
+        var classToggler = ( disabled ) ? this.addClass : this.removeClass;
+        classToggler( classes.disabled );
+        this.attr( 'disabled', disabled );
+      } );
     }
     // set buttons inactive if appropriate
     toggleButtons(
       data.pagination.currentPage === 1,
-      [data.$linkFirstPage, data.$linkPrevPage]);
+      [ data.$linkFirstPage, data.$linkPrevPage ] );
     toggleButtons(
       data.pagination.currentPage === data.pagination.lastPage,
-      [data.$linkLastPage, data.$linkNextPage]);
+      [ data.$linkLastPage, data.$linkNextPage ] );
 
     // update page number tracker
-    data.$pointerThisPage.text(data.pagination.currentPage);
-    data.$pointerLastPage.text(data.pagination.lastPage);
+    data.$pointerThisPage.text( data.pagination.currentPage );
+    data.$pointerLastPage.text( data.pagination.lastPage );
   },
 
-  goToPage: function(page) {
-    var data = this.data(pluginName);
-    var newFirstRowNum = (page - 1) * data.pagination.recordsPerPage;
+  goToPage: function( page ) {
+    var data = this.data( pluginName );
+    var newFirstRowNum = ( page - 1 ) * data.pagination.recordsPerPage;
     var newLastRowNum = Math.min(
       newFirstRowNum + data.pagination.recordsPerPage,
-      data.$records.length);
+      data.$records.length );
 
     // check for valid page number
     if ( page < 1 || page > data.pagination.lastPage ) {
@@ -410,24 +410,24 @@ var methods = {
     // update page number and display page's rows
     data.pagination.currentPage = page;
     data.$records.remove();
-    this.find('tbody').append(
-      data.$records.slice(newFirstRowNum, newLastRowNum));
+    this.find( 'tbody' ).append(
+      data.$records.slice( newFirstRowNum, newLastRowNum ) );
 
     // update pagination tools
-    methods.updatePaginationTools.call(this);
+    methods.updatePaginationTools.call( this );
   },
 };
 
 // Install timbles jQuery plugin
-$.fn[pluginName] = function (method) {
-  if ( methods.hasOwnProperty(method) ) {
-    var methodArgs = Array.prototype.slice.call(arguments, 1);
-    return methods[method].apply(this, methodArgs);
+$.fn[ pluginName ] = function( method ) {
+  if ( methods.hasOwnProperty( method ) ) {
+    var methodArgs = Array.prototype.slice.call( arguments, 1 );
+    return methods[ method ].apply( this, methodArgs );
   }
   if ( typeof method === 'object' || !method ) {
-    return methods.init.apply(this, arguments);
+    return methods.init.apply( this, arguments );
   }
-  $.error('The method ' + method + ' literally does not exist. Good job.');
+  $.error( 'The method ' + method + ' literally does not exist. Good job.' );
 };
 
 } )( jQuery );

--- a/timbles.js
+++ b/timbles.js
@@ -7,427 +7,427 @@
 * @author jenn schiffer http://jennmoney.biz
 */
 
-(function($) {
+( function( $ ) {
 
-  'use strict';
+'use strict';
 
-  var pluginName = 'timbles';
+var pluginName = 'timbles';
 
-  var defaults = {
-    sortKey : null,
-    sortOrder : null,
-  };
+var defaults = {
+  sortKey : null,
+  sortOrder : null,
+};
 
-  var classes = {
-    disabled : 'disabled',
-    active : 'active',
-    headerRow : 'header-row',
-    label : 'label',
-    sortASC : 'sorted-asc',
-    sortDESC : 'sorted-desc',
-    noSort : 'no-sort',
-    paginationToolsContainer : 'pagination',
-    paginationNavArrows : 'nav-arrows',
-    paginationNavRowCountChoice : 'row-count-choice'
-  };
+var classes = {
+  disabled : 'disabled',
+  active : 'active',
+  headerRow : 'header-row',
+  label : 'label',
+  sortASC : 'sorted-asc',
+  sortDESC : 'sorted-desc',
+  noSort : 'no-sort',
+  paginationToolsContainer : 'pagination',
+  paginationNavArrows : 'nav-arrows',
+  paginationNavRowCountChoice : 'row-count-choice'
+};
 
-  var copy = {
-    firstPageArrow : ' << ',
-    prevPageArrow : ' < ',
-    nextPageArrow : ' > ',
-    lastPageArrow : ' >> ',
-    page : 'page',
-    of : 'of'
-  };
+var copy = {
+  firstPageArrow : ' << ',
+  prevPageArrow : ' < ',
+  nextPageArrow : ' > ',
+  lastPageArrow : ' >> ',
+  page : 'page',
+  of : 'of'
+};
 
-  var methods = {
+var methods = {
 
-    /** initialize timble, er, i mean table **/
-    init : function(opts) {
-      return this.each(function() {
-        var $this = $(this).addClass(pluginName);
-        var options = $.extend({}, defaults, opts);
-        var data = {
-          dataConfig: methods.parseDataConfig(options.dataConfig),
-          sorting: options.sorting,
-          pagination: options.pagination,
-        };
-        $this.data(pluginName, data);
+  /** initialize timble, er, i mean table **/
+  init : function(opts) {
+    return this.each(function() {
+      var $this = $(this).addClass(pluginName);
+      var options = $.extend({}, defaults, opts);
+      var data = {
+        dataConfig: methods.parseDataConfig(options.dataConfig),
+        sorting: options.sorting,
+        pagination: options.pagination,
+      };
+      $this.data(pluginName, data);
 
-        if ( data.dataConfig ) {
-          // generate table from JSON
-          methods.generateTableFromJson.call($this);
-        }
-        else {
-          // set up existing html table
-          methods.setupExistingTable.call($this);
-        }
-      });
-    },
-
-    parseDataConfig : function(dataConfig) {
-      if (!(dataConfig instanceof Object)) {
-        return dataConfig;
+      if ( data.dataConfig ) {
+        // generate table from JSON
+        methods.generateTableFromJson.call($this);
       }
-      else if (dataConfig.hasOwnProperty('columns')) {
-        $.each(dataConfig.columns, function(index, columnConfig) {
-          if (columnConfig.hasOwnProperty('dataFilter') &&
-              !columnConfig.hasOwnProperty('textTransform')) {
-            // If a dataFilter is defined (old-style) and no textTransform,
-            // use the dataFilter as textTransform
-            columnConfig.textTransform = columnConfig.dataFilter;
-          }
-          else if (!columnConfig.hasOwnProperty('textTransform')) {
-            // Add a do-nothing textTransform if none is provided
-            columnConfig.textTransform = function (obj) {return obj;};
-          }
-          if (!columnConfig.hasOwnProperty('valueTransform')) {
-            // Add a do-nothing valueTransform if none is provided
-            columnConfig.valueTransform = function (obj) {return obj;};
-          }
-        });
+      else {
+        // set up existing html table
+        methods.setupExistingTable.call($this);
       }
+    });
+  },
+
+  parseDataConfig : function(dataConfig) {
+    if (!(dataConfig instanceof Object)) {
       return dataConfig;
-    },
-
-    setupExistingTable : function() {
-      var data = this.data(pluginName);
-
-      // for each header cell, store its column number
-      var $headerRow = data.$headerRow = this.find('thead tr').eq(0)
-        .addClass(classes.headerRow);
-      $headerRow.find('th').each(function(index) {
-        $(this).data('timbles-column-index', index);
+    }
+    else if (dataConfig.hasOwnProperty('columns')) {
+      $.each(dataConfig.columns, function(index, columnConfig) {
+        if (columnConfig.hasOwnProperty('dataFilter') &&
+            !columnConfig.hasOwnProperty('textTransform')) {
+          // If a dataFilter is defined (old-style) and no textTransform,
+          // use the dataFilter as textTransform
+          columnConfig.textTransform = columnConfig.dataFilter;
+        }
+        else if (!columnConfig.hasOwnProperty('textTransform')) {
+          // Add a do-nothing textTransform if none is provided
+          columnConfig.textTransform = function (obj) {return obj;};
+        }
+        if (!columnConfig.hasOwnProperty('valueTransform')) {
+          // Add a do-nothing valueTransform if none is provided
+          columnConfig.valueTransform = function (obj) {return obj;};
+        }
       });
+    }
+    return dataConfig;
+  },
+
+  setupExistingTable : function() {
+    var data = this.data(pluginName);
+
+    // for each header cell, store its column number
+    var $headerRow = data.$headerRow = this.find('thead tr').eq(0)
+      .addClass(classes.headerRow);
+    $headerRow.find('th').each(function(index) {
+      $(this).data('timbles-column-index', index);
+    });
+
+    // start enabling any given features
+    methods.enableFeaturesSetup.call(this);
+  },
+
+  generateTableFromJson : function() {
+    var data = this.data(pluginName);
+    var $headerRow = data.$headerRow = $('<tr>')
+      .addClass(classes.headerRow)
+      .appendTo($('<thead>').appendTo(this));
+
+    // generate and add cell headers to header row
+    $.each(data.dataConfig.columns, function(index, value) {
+      $('<th>')
+        .attr('id', value.id)
+        .addClass(value.noSorting ? classes.noSort : null)
+        .data('timbles-column-index', index)
+        .text(value.label)
+        .appendTo($headerRow);
+    });
+
+    if ($.isArray(data.dataConfig.data)) {
+      // no need for ajax call if data is local array
+      methods.generateRowsFromData.call(this, data.dataConfig.data, data.dataConfig.columns);
 
       // start enabling any given features
       methods.enableFeaturesSetup.call(this);
-    },
-
-    generateTableFromJson : function() {
-      var data = this.data(pluginName);
-      var $headerRow = data.$headerRow = $('<tr>')
-        .addClass(classes.headerRow)
-        .appendTo($('<thead>').appendTo(this));
-
-      // generate and add cell headers to header row
-      $.each(data.dataConfig.columns, function(index, value) {
-        $('<th>')
-          .attr('id', value.id)
-          .addClass(value.noSorting ? classes.noSort : null)
-          .data('timbles-column-index', index)
-          .text(value.label)
-          .appendTo($headerRow);
-      });
-
-      if ($.isArray(data.dataConfig.data)) {
-        // no need for ajax call if data is local array
-        methods.generateRowsFromData.call(this, data.dataConfig.data, data.dataConfig.columns);
-
+    }
+    else {
+      // get external json file given
+      $.getJSON( data.dataConfig.data, function(json) {
+        methods.generateRowsFromData.call(this, json, data.dataConfig.columns);
+      }.bind(this)).then(function(){
         // start enabling any given features
         methods.enableFeaturesSetup.call(this);
-      }
-      else {
-        // get external json file given
-        $.getJSON( data.dataConfig.data, function(json) {
-          methods.generateRowsFromData.call(this, json, data.dataConfig.columns);
-        }.bind(this)).then(function(){
-          // start enabling any given features
-          methods.enableFeaturesSetup.call(this);
-        }.bind(this));
-      }
-    },
-
-    generateRowsFromData : function(rowData, columnConfig) {
-      $.each(rowData, function(index, row) {
-        // Add rows to the current table
-        var $newRow = $('<tr>').appendTo(this);
-        $.each(columnConfig, function(index, column) {
-          // Add cells to the current row
-          var cellValue = row[column.id];
-          $('<td>')
-            .attr('data-value', column.valueTransform(cellValue))
-            .text(column.textTransform(cellValue))
-            .appendTo(this);
-        }.bind($newRow));
       }.bind(this));
-    },
+    }
+  },
 
-    enableFeaturesSetup : function() {
+  generateRowsFromData : function(rowData, columnConfig) {
+    $.each(rowData, function(index, row) {
+      // Add rows to the current table
+      var $newRow = $('<tr>').appendTo(this);
+      $.each(columnConfig, function(index, column) {
+        // Add cells to the current row
+        var cellValue = row[column.id];
+        $('<td>')
+          .attr('data-value', column.valueTransform(cellValue))
+          .text(column.textTransform(cellValue))
+          .appendTo(this);
+      }.bind($newRow));
+    }.bind(this));
+  },
+
+  enableFeaturesSetup : function() {
+    var data = this.data(pluginName);
+    data.$records = this.find('tbody tr');
+
+    if ( data.sorting ) {
+      methods.enableSorting.call(this);
+
+      if ( data.sorting.keyId ) {
+        methods.sortColumn.call(this, data.sorting.keyId, data.sorting.order);
+      }
+    }
+
+    if ( data.pagination ) {
+      methods.enablePagination.call(this, data.pagination.recordsPerPage);
+    }
+  },
+
+  enableSorting : function() {
+    this.find('th').not('.no-sort').on(
+      'click', methods.sortColumnEvent.bind(this));
+  },
+
+  sortColumn : function(key, order) {
+    // Sort a column identified by its key in a given order
+    // If `key` is numeric, it is treated as the column index to sort
+    // If `order` is not given, this will do the same as clicking the header
+    if (typeof key === "number") {
       var data = this.data(pluginName);
+      data.$headerRow.find('th').eq(key).trigger('click', order);
+    }
+    else {
+      this.find('#' + key).trigger('click', order);
+    }
+  },
+
+  sortColumnEvent : function(event, order) {
+    var data = this.data(pluginName);
+
+    // determine order and update header sort classes
+    var $sortHeader = $(event.target);
+    var sortColumn = $sortHeader.data('timbles-column-index');
+
+    if ( !order ) {
+      order = $sortHeader.hasClass(classes.sortASC) ? 'desc' : 'asc';
+    }
+    data.$headerRow.find('th')
+      .removeClass(classes.sortASC)
+      .removeClass(classes.sortDESC);
+    $sortHeader.addClass((order === 'asc') ? classes.sortASC : classes.sortDESC);
+
+    // determine column values to actually sort by
+    var sortMap = data.$records.map(function() {
+      var cell = this.children[sortColumn];
+      var dataValue = cell.getAttribute('data-value');
+      if (dataValue === null) {
+        dataValue = cell.textContent || cell.innerText;
+      }
+      else if (parseFloat(dataValue).toString() === dataValue) {
+        dataValue = parseFloat(dataValue);
+      }
+      return {
+        node: this,
+        value: dataValue
+      };
+    });
+
+    // sort the mapping by the extract column values
+    sortMap.sort(function(a, b) {
+      if (a.value > b.value) {
+        return (order === 'asc') ? 1 : -1;
+      }
+      if (a.value < b.value) {
+        return (order === 'asc') ? -1 : 1;
+      }
+      return 0;
+    });
+
+    // use sortMap to shuffle table rows to the correct order
+    // work on detached DOM for improved performance on large tables
+    var tableBody = this.find('tbody').detach().get(0);
+    sortMap.each(function() {
+      tableBody.appendChild(this.node);
+    });
+
+    $(tableBody).appendTo(this);
+
+    // if table was paginated, reenable
+    if ( data.pagination ) {
       data.$records = this.find('tbody tr');
-
-      if ( data.sorting ) {
-        methods.enableSorting.call(this);
-
-        if ( data.sorting.keyId ) {
-          methods.sortColumn.call(this, data.sorting.keyId, data.sorting.order);
-        }
-      }
-
-      if ( data.pagination ) {
-        methods.enablePagination.call(this, data.pagination.recordsPerPage);
-      }
-    },
-
-    enableSorting : function() {
-      this.find('th').not('.no-sort').on(
-        'click', methods.sortColumnEvent.bind(this));
-    },
-
-    sortColumn : function(key, order) {
-      // Sort a column identified by its key in a given order
-      // If `key` is numeric, it is treated as the column index to sort
-      // If `order` is not given, this will do the same as clicking the header
-      if (typeof key === "number") {
-        var data = this.data(pluginName);
-        data.$headerRow.find('th').eq(key).trigger('click', order);
-      }
-      else {
-        this.find('#' + key).trigger('click', order);
-      }
-    },
-
-    sortColumnEvent : function(event, order) {
-      var data = this.data(pluginName);
-
-      // determine order and update header sort classes
-      var $sortHeader = $(event.target);
-      var sortColumn = $sortHeader.data('timbles-column-index');
-
-      if ( !order ) {
-        order = $sortHeader.hasClass(classes.sortASC) ? 'desc' : 'asc';
-      }
-      data.$headerRow.find('th')
-        .removeClass(classes.sortASC)
-        .removeClass(classes.sortDESC);
-      $sortHeader.addClass((order === 'asc') ? classes.sortASC : classes.sortDESC);
-
-      // determine column values to actually sort by
-      var sortMap = data.$records.map(function() {
-        var cell = this.children[sortColumn];
-        var dataValue = cell.getAttribute('data-value');
-        if (dataValue === null) {
-          dataValue = cell.textContent || cell.innerText;
-        }
-        else if (parseFloat(dataValue).toString() === dataValue) {
-          dataValue = parseFloat(dataValue);
-        }
-        return {
-          node: this,
-          value: dataValue
-        };
-      });
-
-      // sort the mapping by the extract column values
-      sortMap.sort(function(a, b) {
-        if (a.value > b.value) {
-          return (order === 'asc') ? 1 : -1;
-        }
-        if (a.value < b.value) {
-          return (order === 'asc') ? -1 : 1;
-        }
-        return 0;
-      });
-
-      // use sortMap to shuffle table rows to the correct order
-      // work on detached DOM for improved performance on large tables
-      var tableBody = this.find('tbody').detach().get(0);
-      sortMap.each(function() {
-        tableBody.appendChild(this.node);
-      });
-
-      $(tableBody).appendTo(this);
-
-      // if table was paginated, reenable
-      if ( data.pagination ) {
-        data.$records = this.find('tbody tr');
-        methods.goToPage.call(this, 1);
-      }
-    },
-
-    enablePagination : function(count) {
-      var data = this.data(pluginName);
-      // don't paginate if there are no records
-      if (!data.$records || data.$records.length === 0 ) { return; }
-
-      // Update pagination page size and count
-      data.pagination.currentPage = 1;
-      data.pagination.recordsPerPage = count;
-      data.pagination.lastPage = Math.ceil(data.$records.length / count);
-
-      // Create tools if they don't exist yet
-      if ( !data.$paginationToolsContainer ) {
-        methods.generatePaginationTools.call(this);
-      }
-
-      // Actually place records for the first page
       methods.goToPage.call(this, 1);
-    },
+    }
+  },
 
-    generatePaginationTools : function() {
-      var data = this.data(pluginName);
+  enablePagination : function(count) {
+    var data = this.data(pluginName);
+    // don't paginate if there are no records
+    if (!data.$records || data.$records.length === 0 ) { return; }
 
-      data.$paginationToolsContainer = $('<div>')
-        .addClass(classes.paginationToolsContainer)
-        .insertAfter(this);
+    // Update pagination page size and count
+    data.pagination.currentPage = 1;
+    data.pagination.recordsPerPage = count;
+    data.pagination.lastPage = Math.ceil(data.$records.length / count);
 
-      if ( !data.pagination.nav ) {
-        // by default, just show arrow nav
-        methods.generatePaginationNavArrows.call(this);
-      }
-      else {
-        // iterate through nav object and add tools to footer
-        for ( var navObject in data.pagination.nav ) {
-          switch (navObject) {
-            // arrows
-            case "arrows":
-              methods.generatePaginationNavArrows.call(this);
-              break;
-            // row count choice
-            case "rowCountChoice":
-              methods.generatePaginationNavRowCountChoice.call(this);
-              break;
-          }
+    // Create tools if they don't exist yet
+    if ( !data.$paginationToolsContainer ) {
+      methods.generatePaginationTools.call(this);
+    }
+
+    // Actually place records for the first page
+    methods.goToPage.call(this, 1);
+  },
+
+  generatePaginationTools : function() {
+    var data = this.data(pluginName);
+
+    data.$paginationToolsContainer = $('<div>')
+      .addClass(classes.paginationToolsContainer)
+      .insertAfter(this);
+
+    if ( !data.pagination.nav ) {
+      // by default, just show arrow nav
+      methods.generatePaginationNavArrows.call(this);
+    }
+    else {
+      // iterate through nav object and add tools to footer
+      for ( var navObject in data.pagination.nav ) {
+        switch (navObject) {
+          // arrows
+          case "arrows":
+            methods.generatePaginationNavArrows.call(this);
+            break;
+          // row count choice
+          case "rowCountChoice":
+            methods.generatePaginationNavRowCountChoice.call(this);
+            break;
         }
       }
+    }
 
-      // update tools
-      methods.updatePaginationTools.call(this);
-    },
+    // update tools
+    methods.updatePaginationTools.call(this);
+  },
 
-    generatePaginationNavArrows : function() {
-      var data = this.data(pluginName);
+  generatePaginationNavArrows : function() {
+    var data = this.data(pluginName);
 
-      data.$linkFirstPage = $('<button role="button">').text(copy.firstPageArrow);
-      data.$linkPrevPage = $('<button role="button">').text(copy.prevPageArrow);
-      data.$linkNextPage = $('<button role="button">').text(copy.nextPageArrow);
-      data.$linkLastPage = $('<button role="button">').text(copy.lastPageArrow);
-      var $pageNumberTracker = $('<span>')
-        .addClass('page-number-tracker')
-        .text(copy.page + ' ')
-        .append($('<span>').addClass('pointer-this-page').text(data.pagination.currentPage))
-        .append(' ' + copy.of + ' ')
-        .append($('<span>').addClass('pointer-last-page').text(data.pagination.lastPage));
+    data.$linkFirstPage = $('<button role="button">').text(copy.firstPageArrow);
+    data.$linkPrevPage = $('<button role="button">').text(copy.prevPageArrow);
+    data.$linkNextPage = $('<button role="button">').text(copy.nextPageArrow);
+    data.$linkLastPage = $('<button role="button">').text(copy.lastPageArrow);
+    var $pageNumberTracker = $('<span>')
+      .addClass('page-number-tracker')
+      .text(copy.page + ' ')
+      .append($('<span>').addClass('pointer-this-page').text(data.pagination.currentPage))
+      .append(' ' + copy.of + ' ')
+      .append($('<span>').addClass('pointer-last-page').text(data.pagination.lastPage));
 
-      data.$pointerThisPage = $pageNumberTracker.find('.pointer-this-page');
-      data.$pointerLastPage = $pageNumberTracker.find('.pointer-last-page');
-      $('<div>')
-        .addClass(classes.paginationNavArrows)
-        .append(data.$linkFirstPage)
-        .append(data.$linkPrevPage)
-        .append($pageNumberTracker)
-        .append(data.$linkNextPage)
-        .append(data.$linkLastPage)
-        .appendTo(data.$paginationToolsContainer);
+    data.$pointerThisPage = $pageNumberTracker.find('.pointer-this-page');
+    data.$pointerLastPage = $pageNumberTracker.find('.pointer-last-page');
+    $('<div>')
+      .addClass(classes.paginationNavArrows)
+      .append(data.$linkFirstPage)
+      .append(data.$linkPrevPage)
+      .append($pageNumberTracker)
+      .append(data.$linkNextPage)
+      .append(data.$linkLastPage)
+      .appendTo(data.$paginationToolsContainer);
 
-      // event listeners
-      data.$linkFirstPage.click(function(){
-        methods.goToPage.call(this, 1);
-      }.bind(this));
+    // event listeners
+    data.$linkFirstPage.click(function(){
+      methods.goToPage.call(this, 1);
+    }.bind(this));
 
-      data.$linkPrevPage.click(function(){
-        if ( data.pagination.currentPage > 1) {
-          methods.goToPage.call(this, data.pagination.currentPage - 1);
-        }
-      }.bind(this));
+    data.$linkPrevPage.click(function(){
+      if ( data.pagination.currentPage > 1) {
+        methods.goToPage.call(this, data.pagination.currentPage - 1);
+      }
+    }.bind(this));
 
-      data.$linkNextPage.click(function(){
-        if ( data.pagination.currentPage < data.pagination.lastPage ) {
-          methods.goToPage.call(this, data.pagination.currentPage + 1);
-        }
-      }.bind(this));
+    data.$linkNextPage.click(function(){
+      if ( data.pagination.currentPage < data.pagination.lastPage ) {
+        methods.goToPage.call(this, data.pagination.currentPage + 1);
+      }
+    }.bind(this));
 
-      data.$linkLastPage.click(function(){
-        methods.goToPage.call(this, data.pagination.lastPage);
-      }.bind(this));
-    },
+    data.$linkLastPage.click(function(){
+      methods.goToPage.call(this, data.pagination.lastPage);
+    }.bind(this));
+  },
 
-    generatePaginationNavRowCountChoice : function() {
-      var pageSizeChangeEvent, pageSizeSelection;
-      var data = this.data(pluginName);
+  generatePaginationNavRowCountChoice : function() {
+    var pageSizeChangeEvent, pageSizeSelection;
+    var data = this.data(pluginName);
 
-      pageSizeSelection = $('<div>')
-        .addClass(classes.paginationNavRowCountChoice)
-        .appendTo(data.$paginationToolsContainer);
+    pageSizeSelection = $('<div>')
+      .addClass(classes.paginationNavRowCountChoice)
+      .appendTo(data.$paginationToolsContainer);
 
-      pageSizeChangeEvent = function(event) {
-        var $target = $(event.target).addClass(classes.active)
-        $target.siblings().removeClass(classes.active);
-        var pageSize = $target.text();
+    pageSizeChangeEvent = function(event) {
+      var $target = $(event.target).addClass(classes.active)
+      $target.siblings().removeClass(classes.active);
+      var pageSize = $target.text();
 
-        if ( pageSize.toLowerCase() === 'all' ) {
-          pageSize = data.$records.length;
-        }
+      if ( pageSize.toLowerCase() === 'all' ) {
+        pageSize = data.$records.length;
+      }
 
-        methods.enablePagination.call(this, parseInt(pageSize));
-      }.bind(this);
+      methods.enablePagination.call(this, parseInt(pageSize));
+    }.bind(this);
 
-      $.each(data.pagination.nav.rowCountChoice, function() {
-        $('<button>')
-          .attr('role', 'button')
-          .text(this)
-          .on('click', pageSizeChangeEvent)
-          .appendTo(pageSizeSelection);
+    $.each(data.pagination.nav.rowCountChoice, function() {
+      $('<button>')
+        .attr('role', 'button')
+        .text(this)
+        .on('click', pageSizeChangeEvent)
+        .appendTo(pageSizeSelection);
+    });
+  },
+
+  updatePaginationTools : function() {
+    var data = this.data(pluginName);
+
+    function toggleButtons(disabled, buttons) {
+      $.each(buttons, function() {
+        var classToggler = (disabled) ? this.addClass : this.removeClass;
+        classToggler(classes.disabled);
+        this.attr('disabled', disabled);
       });
-    },
-
-    updatePaginationTools : function() {
-      var data = this.data(pluginName);
-
-      function toggleButtons(disabled, buttons) {
-        $.each(buttons, function() {
-          var classToggler = (disabled) ? this.addClass : this.removeClass;
-          classToggler(classes.disabled);
-          this.attr('disabled', disabled);
-        });
-      }
-      // set buttons inactive if appropriate
-      toggleButtons(
-        data.pagination.currentPage === 1,
-        [data.$linkFirstPage, data.$linkPrevPage]);
-      toggleButtons(
-        data.pagination.currentPage === data.pagination.lastPage,
-        [data.$linkLastPage, data.$linkNextPage]);
-
-      // update page number tracker
-      data.$pointerThisPage.text(data.pagination.currentPage);
-      data.$pointerLastPage.text(data.pagination.lastPage);
-    },
-
-    goToPage : function(page) {
-      var data = this.data(pluginName);
-      var newFirstRowNum = (page - 1) * data.pagination.recordsPerPage;
-      var newLastRowNum = Math.min(
-        newFirstRowNum + data.pagination.recordsPerPage,
-        data.$records.length);
-
-      // check for valid page number
-      if ( page < 1 || page > data.pagination.lastPage ) {
-        return;
-      }
-
-      // update page number and display page's rows
-      data.pagination.currentPage = page;
-      data.$records.remove();
-      this.find('tbody').append(
-        data.$records.slice(newFirstRowNum, newLastRowNum));
-
-      // update pagination tools
-      methods.updatePaginationTools.call(this);
-    },
-  };
-
-  // Install timbles jQuery plugin
-  $.fn[pluginName] = function (method) {
-    if ( methods.hasOwnProperty(method) ) {
-      var methodArgs = Array.prototype.slice.call(arguments, 1);
-      return methods[method].apply(this, methodArgs);
     }
-    if ( typeof method === 'object' || !method ) {
-      return methods.init.apply(this, arguments);
-    }
-    $.error('The method ' + method + ' literally does not exist. Good job.');
-  };
+    // set buttons inactive if appropriate
+    toggleButtons(
+      data.pagination.currentPage === 1,
+      [data.$linkFirstPage, data.$linkPrevPage]);
+    toggleButtons(
+      data.pagination.currentPage === data.pagination.lastPage,
+      [data.$linkLastPage, data.$linkNextPage]);
 
-})( jQuery );
+    // update page number tracker
+    data.$pointerThisPage.text(data.pagination.currentPage);
+    data.$pointerLastPage.text(data.pagination.lastPage);
+  },
+
+  goToPage : function(page) {
+    var data = this.data(pluginName);
+    var newFirstRowNum = (page - 1) * data.pagination.recordsPerPage;
+    var newLastRowNum = Math.min(
+      newFirstRowNum + data.pagination.recordsPerPage,
+      data.$records.length);
+
+    // check for valid page number
+    if ( page < 1 || page > data.pagination.lastPage ) {
+      return;
+    }
+
+    // update page number and display page's rows
+    data.pagination.currentPage = page;
+    data.$records.remove();
+    this.find('tbody').append(
+      data.$records.slice(newFirstRowNum, newLastRowNum));
+
+    // update pagination tools
+    methods.updatePaginationTools.call(this);
+  },
+};
+
+// Install timbles jQuery plugin
+$.fn[pluginName] = function (method) {
+  if ( methods.hasOwnProperty(method) ) {
+    var methodArgs = Array.prototype.slice.call(arguments, 1);
+    return methods[method].apply(this, methodArgs);
+  }
+  if ( typeof method === 'object' || !method ) {
+    return methods.init.apply(this, arguments);
+  }
+  $.error('The method ' + method + ' literally does not exist. Good job.');
+};
+
+} )( jQuery );

--- a/timbles.js
+++ b/timbles.js
@@ -56,8 +56,7 @@ var methods = {
 
       if ( data.dataConfig ) {
         methods.generateTableFromJson.call( $this );
-      }
-      else {
+      } else {
         methods.setupExistingTable.call( $this );
       }
     } );
@@ -66,8 +65,7 @@ var methods = {
   parseDataConfig: function( dataConfig ) {
     if ( !( dataConfig instanceof Object ) ) {
       return dataConfig;
-    }
-    else if ( dataConfig.hasOwnProperty( 'columns' ) ) {
+    } else if ( dataConfig.hasOwnProperty( 'columns' ) ) {
       $.each( dataConfig.columns, function( index, columnConfig ) {
         if ( columnConfig.hasOwnProperty( 'dataFilter' ) &&
              !columnConfig.hasOwnProperty( 'textTransform' ) ) {
@@ -75,8 +73,7 @@ var methods = {
           // If a dataFilter is defined (old-style) and no textTransform,
           // use the dataFilter as textTransform
           columnConfig.textTransform = columnConfig.dataFilter;
-        }
-        else if ( !columnConfig.hasOwnProperty( 'textTransform' ) ) {
+        } else if ( !columnConfig.hasOwnProperty( 'textTransform' ) ) {
 
           // Add a do-nothing textTransform if none is provided
           columnConfig.textTransform = function( obj ) { return obj; };
@@ -128,8 +125,7 @@ var methods = {
 
       // Start enabling any given features
       methods.enableFeaturesSetup.call( this );
-    }
-    else {
+    } else {
 
       // Get external json file given
       $.getJSON( data.dataConfig.data, function( json ) {
@@ -189,8 +185,7 @@ var methods = {
     if ( typeof key === 'number' ) {
       var data = this.data( pluginName );
       data.$headerRow.find( 'th' ).eq( key ).trigger( 'click', order );
-    }
-    else {
+    } else {
       this.find( '#' + key ).trigger( 'click', order );
     }
   },
@@ -216,8 +211,7 @@ var methods = {
       var dataValue = cell.getAttribute( 'data-value' );
       if ( dataValue === null ) {
         dataValue = cell.textContent || cell.innerText;
-      }
-      else if ( parseFloat( dataValue ).toString() === dataValue ) {
+      } else if ( parseFloat( dataValue ).toString() === dataValue ) {
         dataValue = parseFloat( dataValue );
       }
       return {
@@ -284,8 +278,7 @@ var methods = {
 
       // If no pagination is configured, default to showing arrows only
       methods.generatePaginationNavArrows.call( this );
-    }
-    else {
+    } else {
       for ( var navObject in data.pagination.nav ) {
         switch ( navObject ) {
           case 'arrows':

--- a/timbles.js
+++ b/timbles.js
@@ -15,7 +15,7 @@ var pluginName = 'timbles';
 
 var defaults = {
   sortKey: null,
-  sortOrder: null,
+  sortOrder: null
 };
 
 var classes = {
@@ -50,7 +50,7 @@ var methods = {
       var data = {
         dataConfig: methods.parseDataConfig( options.dataConfig ),
         sorting: options.sorting,
-        pagination: options.pagination,
+        pagination: options.pagination
       };
       $this.data( pluginName, data );
 
@@ -186,7 +186,7 @@ var methods = {
     // Sort a column identified by its key in a given order
     // If `key` is numeric, it is treated as the column index to sort
     // If `order` is not given, this will do the same as clicking the header
-    if ( typeof key === "number" ) {
+    if ( typeof key === 'number' ) {
       var data = this.data( pluginName );
       data.$headerRow.find( 'th' ).eq( key ).trigger( 'click', order );
     }
@@ -288,10 +288,10 @@ var methods = {
     else {
       for ( var navObject in data.pagination.nav ) {
         switch ( navObject ) {
-          case "arrows":
+          case 'arrows':
             methods.generatePaginationNavArrows.call( this );
             break;
-          case "rowCountChoice":
+          case 'rowCountChoice':
             methods.generatePaginationNavRowCountChoice.call( this );
             break;
         }
@@ -356,7 +356,7 @@ var methods = {
       .appendTo( data.$paginationToolsContainer );
 
     pageSizeChangeEvent = function( event ) {
-      var $target = $( event.target ).addClass( classes.active )
+      var $target = $( event.target ).addClass( classes.active );
       $target.siblings().removeClass( classes.active );
       var pageSize = $target.text();
 
@@ -420,7 +420,7 @@ var methods = {
 
     // Update pagination tools
     methods.updatePaginationTools.call( this );
-  },
+  }
 };
 
 // Install timbles jQuery plugin


### PR DESCRIPTION
Hi Jen,

I stumbled upon [JSCS](http://jscs.info/) earlier tonight and it seemed like just the tool to use here. PR contains a number of separate commits that fix indentation, whitespace and various other style bits to bring the code in line with jQuery style. (some of those commits touch all or most of the code, but only do small whitespace things, so I kept them separate to make it slightly easier to see what happens in the others).

I've also added a simple grunt script that makes verifying everything's in proper order a bit easier. Running `grunt` verifies timbles using JSHint first JSCS after, which should be plenty to keep poor code and style out.

This also resolves #19 
