### PR TITLE
Improve pagination buttons

### DIFF
--- a/tests/test-scripts/pagination.js
+++ b/tests/test-scripts/pagination.js
@@ -59,6 +59,14 @@ QUnit.test( 'Correct number of total pages ...', function( assert ) {
   assert.equal( pageNumber.text(), '6', '... in page navigation block' );
 } );
 
+QUnit.test( 'Correct button (dis|en)able state on first page', function( assert ) {
+  var navigationButtons = target.next().find( '.nav-arrows button' );
+  assert.ok( navigationButtons.eq( 0 ).attr( 'disabled' ), 'First button disabled' );
+  assert.ok( navigationButtons.eq( 1 ).attr( 'disabled' ), 'Previous button disabled' );
+  assert.notOk( navigationButtons.eq( 2 ).attr( 'disabled' ), 'Next button enabled' );
+  assert.notOk( navigationButtons.eq( 3 ).attr( 'disabled' ), 'Last button enabled' );
+} );
+
 /* Tests of navigation and related behavior
  *
  */
@@ -88,7 +96,7 @@ QUnit.test( 'Go to second page by clicking nav button', function( assert ) {
   );
 } );
 
-QUnit.test( 'Go to page by using goToPage method', function( assert ) {
+QUnit.test( 'Go to last page by using goToPage method', function( assert ) {
   var paginationData = target.data( 'timbles' ).pagination;
   var pageNumber = target.next().find( '.pointer-this-page' );
   var expectedPageContent = [ 'Zacatecas' ];
@@ -101,6 +109,14 @@ QUnit.test( 'Go to page by using goToPage method', function( assert ) {
     expectedPageContent,
     'Correct content and length for page'
   );
+} );
+
+QUnit.test( 'Correct button (dis|en)able state on last page', function( assert ) {
+  var navigationButtons = target.next().find( '.nav-arrows button' );
+  assert.notOk( navigationButtons.eq( 0 ).attr( 'disabled' ), 'First button enabled' );
+  assert.notOk( navigationButtons.eq( 1 ).attr( 'disabled' ), 'Previous button enabled' );
+  assert.ok( navigationButtons.eq( 2 ).attr( 'disabled' ), 'Next button disabled' );
+  assert.ok( navigationButtons.eq( 3 ).attr( 'disabled' ), 'Last button disabled' );
 } );
 
 QUnit.test( 'Sorting resets to first page', function( assert ) {

--- a/timbles.js
+++ b/timbles.js
@@ -374,6 +374,7 @@ var methods = {
         .attr( 'type', 'button' )
         .on( 'click', pageSizeChangeEvent )
         .text( this )
+        .toggleClass( classes.active, data.pagination.recordsPerPage === this )
         .appendTo( pageSizeSelection );
     } );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -328,23 +328,23 @@ var methods = {
       .appendTo( data.$paginationToolsContainer );
 
     // Register event listeners
-    data.$linkFirstPage.click( function() {
+    data.$linkFirstPage.on( 'click', function() {
       methods.goToPage.call( this, 1 );
     }.bind( this ) );
 
-    data.$linkPrevPage.click( function() {
+    data.$linkPrevPage.on( 'click', function() {
       if ( data.pagination.currentPage > 1 ) {
         methods.goToPage.call( this, data.pagination.currentPage - 1 );
       }
     }.bind( this ) );
 
-    data.$linkNextPage.click( function() {
+    data.$linkNextPage.on( 'click', function() {
       if ( data.pagination.currentPage < data.pagination.lastPage ) {
         methods.goToPage.call( this, data.pagination.currentPage + 1 );
       }
     }.bind( this ) );
 
-    data.$linkLastPage.click( function() {
+    data.$linkLastPage.on( 'click', function() {
       methods.goToPage.call( this, data.pagination.lastPage );
     }.bind( this ) );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -303,11 +303,12 @@ var methods = {
 
   generatePaginationNavArrows: function() {
     var data = this.data( pluginName );
+    var $navButton = $( '<button>' ).attr( 'type', 'button' );
 
-    data.$linkFirstPage = $( '<button role="button">' ).text( copy.firstPageArrow );
-    data.$linkPrevPage = $( '<button role="button">' ).text( copy.prevPageArrow );
-    data.$linkNextPage = $( '<button role="button">' ).text( copy.nextPageArrow );
-    data.$linkLastPage = $( '<button role="button">' ).text( copy.lastPageArrow );
+    data.$linkFirstPage = $navButton.clone().text( copy.firstPageArrow );
+    data.$linkPrevPage = $navButton.clone().text( copy.prevPageArrow );
+    data.$linkNextPage = $navButton.clone().text( copy.nextPageArrow );
+    data.$linkLastPage = $navButton.clone().text( copy.lastPageArrow );
     var $pageNumberTracker = $( '<span>' )
       .addClass( 'page-number-tracker' )
       .text( copy.page + ' ' )
@@ -370,9 +371,9 @@ var methods = {
 
     $.each( data.pagination.nav.rowCountChoice, function() {
       $( '<button>' )
-        .attr( 'role', 'button' )
-        .text( this )
+        .attr( 'type', 'button' )
         .on( 'click', pageSizeChangeEvent )
+        .text( this )
         .appendTo( pageSizeSelection );
     } );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -382,21 +382,20 @@ var methods = {
   updatePaginationTools: function() {
     var data = this.data( pluginName );
 
-    function toggleButtons( disabled, buttons ) {
+    function toggleButtons( buttons, disabled ) {
       $.each( buttons, function() {
-        var classToggler = ( disabled ) ? this.addClass : this.removeClass;
-        classToggler( classes.disabled );
+        this.toggleClass( classes.disabled, disabled );
         this.attr( 'disabled', disabled );
       } );
     }
 
     // Set buttons inactive if appropriate
     toggleButtons(
-      data.pagination.currentPage === 1,
-      [ data.$linkFirstPage, data.$linkPrevPage ] );
+      [ data.$linkFirstPage, data.$linkPrevPage ],
+      data.pagination.currentPage === 1 );
     toggleButtons(
-      data.pagination.currentPage === data.pagination.lastPage,
-      [ data.$linkLastPage, data.$linkNextPage ] );
+      [ data.$linkLastPage, data.$linkNextPage ],
+      data.pagination.currentPage === data.pagination.lastPage );
 
     // Update page number tracker
     data.$pointerThisPage.text( data.pagination.currentPage );


### PR DESCRIPTION
Some nice things that changed here:
- Removed redundant ARIA `role` and added required `type` attribute to buttons (this resolves #30)
- All handlers throughout the plugin are now set up with `.on()`, keeping things consistent
- When the rowCountChoice buttons are first generated, the `active` class is set for the button that represents the current page size
