### PR TITLE
Improve configuration options and multi-table methods

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -18,6 +18,7 @@
   <ul>
     <li><a href="pagination.html">Tests for pagination of tables</a></li>
     <li><a href="pagination-post-init.html">Pagination tests where sorting and pagination are set up post-timblification</a></li>
+    <li><a href="misc.html">Miscellaneous other tests of timbles.</a></li>
   </ul>
 </body>
 </html>

--- a/tests/misc.html
+++ b/tests/misc.html
@@ -8,6 +8,33 @@
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
+  <div style="display: none">
+
+    <table id="pagination-default-classes">
+      <thead>
+        <tr><th>Header</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Row 1</td></tr>
+        <tr><td>Row 2</td></tr>
+        <tr><td>Row 3</td></tr>
+        <tr><td>Row 4</td></tr>
+      </tbody>
+    </table>
+
+    <table id="pagination-custom-classes">
+      <thead>
+        <tr><th>Header</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Row 1</td></tr>
+        <tr><td>Row 2</td></tr>
+        <tr><td>Row 3</td></tr>
+        <tr><td>Row 4</td></tr>
+      </tbody>
+    </table>
+
+  </div>
   <script type="text/javascript" src="../jquery.js"></script>
   <script type="text/javascript" src="../timbles.js"></script>
   <script src="qunit-1.20.0.js"></script>
@@ -17,6 +44,50 @@
         function() { $.fn.timbles( 'nothingHere' ); },
         /Error(.*?nothingHere.*?)/,
         'Accessing a nonexisting method/member throws an error.' );
+    } );
+
+    QUnit.test( 'Navigation and rowCount buttons have no classes by default', function( assert ) {
+      var paginationConfig = {
+        nav: { arrows: true, rowCountChoice: [ 5, 10 ] },
+        recordsPerPage: 100  // Ensure all navigation is disabled
+      };
+      var paginationContainer = $( '#pagination-default-classes' )
+        .timbles( { pagination: paginationConfig } )
+        .next();
+
+      // Verify pagination buttons have no additional classes
+      assert.expect( 6 );
+      paginationContainer.find( '.nav-arrows button' ).each( function() {
+        assert.equal( $( this ).attr( 'class' ), 'disabled', 'nav button has no extra class' );
+      } );
+      paginationContainer.find( '.row-count-choice button' ).each( function() {
+        assert.notOk( $( this ).attr( 'class' ), 'row count button has no class' );
+      } );
+    } );
+
+    QUnit.test( 'Navigation and rowCount button classes are configurable', function( assert ) {
+      var navigationClass = 'page-nav-button';
+      var rowCountClass = 'row-count-button';
+
+      // Initialize with changed class names
+      var paginationContainer = $( '#pagination-custom-classes' )
+        .timbles( {
+          classes: {
+            paginationNavigationButton: navigationClass,
+            paginationRowCountButton: rowCountClass
+          },
+          pagination: { nav: { arrows: true, rowCountChoice: [ 5, 10 ] } }
+        } )
+        .next();
+
+      // Verify pagination buttons are created with these classes
+      assert.expect( 6 );
+      paginationContainer.find( '.nav-arrows button' ).each( function() {
+        assert.ok( $( this ).hasClass( navigationClass ), 'nav button has class' );
+      } );
+      paginationContainer.find( '.row-count-choice button' ).each( function() {
+        assert.ok( $( this ).hasClass( rowCountClass ), 'row count button has class' );
+      } );
     } );
 
   </script>

--- a/tests/misc.html
+++ b/tests/misc.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>timbles tests &bull; QUnit</title>
+  <link rel="stylesheet" href="qunit-1.20.0.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+  <script type="text/javascript" src="../jquery.js"></script>
+  <script type="text/javascript" src="../timbles.js"></script>
+  <script src="qunit-1.20.0.js"></script>
+  <script type="text/javascript">
+    QUnit.test( 'Accessing nonexisting method raises error', function( assert ) {
+      assert.throws(
+        function() { $.fn.timbles( 'nothingHere' ); },
+        /Error(.*?nothingHere.*?)/,
+        'Accessing a nonexisting method/member throws an error.' );
+    } );
+
+  </script>
+</body>
+</html>

--- a/tests/misc.html
+++ b/tests/misc.html
@@ -34,6 +34,30 @@
       </tbody>
     </table>
 
+    <table class="multi-target" id="multi-target-one">
+      <thead>
+        <tr><th>Letter</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>A</td></tr>
+        <tr><td>B</td></tr>
+        <tr><td>C</td></tr>
+        <tr><td>D</td></tr>
+      </tbody>
+    </table>
+
+    <table class="multi-target" id="multi-target-two">
+      <thead>
+        <tr><th>Letter</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>E</td></tr>
+        <tr><td>F</td></tr>
+        <tr><td>G</td></tr>
+        <tr><td>H</td></tr>
+      </tbody>
+    </table>
+
   </div>
   <script type="text/javascript" src="../jquery.js"></script>
   <script type="text/javascript" src="../timbles.js"></script>
@@ -88,6 +112,16 @@
       paginationContainer.find( '.row-count-choice button' ).each( function() {
         assert.ok( $( this ).hasClass( rowCountClass ), 'row count button has class' );
       } );
+    } );
+
+    QUnit.test( 'Methods can be chained and target multiple tables', function( assert ) {
+      var multiTable = $( '.multi-target' )
+        .timbles()
+        .timbles( 'enablePagination', 1 )
+        .timbles( 'goToPage', 2 );
+      assert.equal( multiTable.length, 2, 'Actually selected two tables' );
+      assert.equal( $( '#multi-target-one tbody td' ).text(), 'B', 'First table followed' );
+      assert.equal( $( '#multi-target-two tbody td' ).text(), 'F', 'Second table followed' );
     } );
 
   </script>

--- a/tests/test-scripts/pagination.js
+++ b/tests/test-scripts/pagination.js
@@ -59,6 +59,14 @@ QUnit.test( 'Correct number of total pages ...', function( assert ) {
   assert.equal( pageNumber.text(), '6', '... in page navigation block' );
 } );
 
+QUnit.test( 'Correct button (dis|en)able state on first page', function( assert ) {
+  var navigationButtons = target.next().find( '.nav-arrows button' );
+  assert.ok( navigationButtons.eq( 0 ).attr( 'disabled' ), 'First button disabled' );
+  assert.ok( navigationButtons.eq( 1 ).attr( 'disabled' ), 'Previous button disabled' );
+  assert.notOk( navigationButtons.eq( 2 ).attr( 'disabled' ), 'Next button enabled' );
+  assert.notOk( navigationButtons.eq( 3 ).attr( 'disabled' ), 'Last button enabled' );
+} );
+
 /* Tests of navigation and related behavior
  *
  */
@@ -88,7 +96,7 @@ QUnit.test( 'Go to second page by clicking nav button', function( assert ) {
   );
 } );
 
-QUnit.test( 'Go to page by using goToPage method', function( assert ) {
+QUnit.test( 'Go to last page by using goToPage method', function( assert ) {
   var paginationData = target.data( 'timbles' ).pagination;
   var pageNumber = target.next().find( '.pointer-this-page' );
   var expectedPageContent = [ 'Zacatecas' ];
@@ -101,6 +109,14 @@ QUnit.test( 'Go to page by using goToPage method', function( assert ) {
     expectedPageContent,
     'Correct content and length for page'
   );
+} );
+
+QUnit.test( 'Correct button (dis|en)able state on last page', function( assert ) {
+  var navigationButtons = target.next().find( '.nav-arrows button' );
+  assert.notOk( navigationButtons.eq( 0 ).attr( 'disabled' ), 'First button enabled' );
+  assert.notOk( navigationButtons.eq( 1 ).attr( 'disabled' ), 'Previous button enabled' );
+  assert.ok( navigationButtons.eq( 2 ).attr( 'disabled' ), 'Next button disabled' );
+  assert.ok( navigationButtons.eq( 3 ).attr( 'disabled' ), 'Last button disabled' );
 } );
 
 QUnit.test( 'Sorting resets to first page', function( assert ) {

--- a/timbles.js
+++ b/timbles.js
@@ -13,11 +13,6 @@
 
 var pluginName = 'timbles';
 
-var defaults = {
-  sortKey: null,
-  sortOrder: null
-};
-
 var classes = {
   disabled: 'disabled',
   active: 'active',

--- a/timbles.js
+++ b/timbles.js
@@ -374,6 +374,7 @@ var methods = {
         .attr( 'type', 'button' )
         .on( 'click', pageSizeChangeEvent )
         .text( this )
+        .toggleClass( classes.active, data.pagination.recordsPerPage === this )
         .appendTo( pageSizeSelection );
     } );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -28,7 +28,9 @@ var classes = {
   noSort: 'no-sort',
   paginationToolsContainer: 'pagination',
   paginationNavArrows: 'nav-arrows',
-  paginationNavRowCountChoice: 'row-count-choice'
+  paginationNavRowCountChoice: 'row-count-choice',
+  paginationNavigationButton: null,
+  paginationRowCountButton: null
 };
 
 var copy = {
@@ -305,7 +307,11 @@ var methods = {
 
   generatePaginationNavArrows: function() {
     var data = this.data( pluginName );
-    var $navButton = $( '<button>' ).attr( 'type', 'button' );
+    var $navButton = $( '<button>' )
+      .attr( 'type', 'button' )
+      .toggleClass(
+        data.classes.paginationNavigationButton,
+        data.classes.paginationNavigationButton );
 
     data.$linkFirstPage = $navButton.clone().text( data.copy.firstPageArrow );
     data.$linkPrevPage = $navButton.clone().text( data.copy.prevPageArrow );
@@ -377,6 +383,9 @@ var methods = {
         .on( 'click', pageSizeChangeEvent )
         .text( this )
         .toggleClass( data.classes.active, data.pagination.recordsPerPage === this )
+        .toggleClass(
+          data.classes.paginationRowCountButton,
+          data.classes.paginationRowCountButton )
         .appendTo( pageSizeSelection );
     } );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -17,10 +17,11 @@ var classes = {
   disabled: 'disabled',
   active: 'active',
   headerRow: 'header-row',
-  label: 'label',
   sortASC: 'sorted-asc',
   sortDESC: 'sorted-desc',
   noSort: 'no-sort',
+  navigationCurrentPage: 'pointer-this-page',
+  navigationLastPage: 'pointer-last-page',
   paginationToolsContainer: 'pagination',
   paginationNavArrows: 'nav-arrows',
   paginationNavRowCountChoice: 'row-count-choice',
@@ -309,15 +310,19 @@ var methods = {
     data.$linkPrevPage = $navButton.clone().text( data.copy.prevPageArrow );
     data.$linkNextPage = $navButton.clone().text( data.copy.nextPageArrow );
     data.$linkLastPage = $navButton.clone().text( data.copy.lastPageArrow );
+    data.$pointerThisPage = $( '<span>' )
+        .addClass( classes.navigationCurrentPage )
+        .text( data.pagination.currentPage );
+    data.$pointerLastPage = $( '<span>' )
+        .addClass( classes.navigationLastPage )
+        .text( data.pagination.lastPage );
     var $pageNumberTracker = $( '<span>' )
       .addClass( 'page-number-tracker' )
       .text( data.copy.page + ' ' )
-      .append( $( '<span>' ).addClass( 'pointer-this-page' ).text( data.pagination.currentPage ) )
+      .append( data.$pointerThisPage )
       .append( ' ' + data.copy.of + ' ' )
-      .append( $( '<span>' ).addClass( 'pointer-last-page' ).text( data.pagination.lastPage ) );
+      .append( data.$pointerLastPage );
 
-    data.$pointerThisPage = $pageNumberTracker.find( '.pointer-this-page' );
-    data.$pointerLastPage = $pageNumberTracker.find( '.pointer-last-page' );
     $( '<div>' )
       .addClass( data.classes.paginationNavArrows )
       .append( data.$linkFirstPage )

--- a/timbles.js
+++ b/timbles.js
@@ -328,23 +328,23 @@ var methods = {
       .appendTo( data.$paginationToolsContainer );
 
     // Register event listeners
-    data.$linkFirstPage.click( function() {
+    data.$linkFirstPage.on( 'click', function() {
       methods.goToPage.call( this, 1 );
     }.bind( this ) );
 
-    data.$linkPrevPage.click( function() {
+    data.$linkPrevPage.on( 'click', function() {
       if ( data.pagination.currentPage > 1 ) {
         methods.goToPage.call( this, data.pagination.currentPage - 1 );
       }
     }.bind( this ) );
 
-    data.$linkNextPage.click( function() {
+    data.$linkNextPage.on( 'click', function() {
       if ( data.pagination.currentPage < data.pagination.lastPage ) {
         methods.goToPage.call( this, data.pagination.currentPage + 1 );
       }
     }.bind( this ) );
 
-    data.$linkLastPage.click( function() {
+    data.$linkLastPage.on( 'click', function() {
       methods.goToPage.call( this, data.pagination.lastPage );
     }.bind( this ) );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -303,11 +303,12 @@ var methods = {
 
   generatePaginationNavArrows: function() {
     var data = this.data( pluginName );
+    var $navButton = $( '<button>' ).attr( 'type', 'button' );
 
-    data.$linkFirstPage = $( '<button role="button">' ).text( copy.firstPageArrow );
-    data.$linkPrevPage = $( '<button role="button">' ).text( copy.prevPageArrow );
-    data.$linkNextPage = $( '<button role="button">' ).text( copy.nextPageArrow );
-    data.$linkLastPage = $( '<button role="button">' ).text( copy.lastPageArrow );
+    data.$linkFirstPage = $navButton.clone().text( copy.firstPageArrow );
+    data.$linkPrevPage = $navButton.clone().text( copy.prevPageArrow );
+    data.$linkNextPage = $navButton.clone().text( copy.nextPageArrow );
+    data.$linkLastPage = $navButton.clone().text( copy.lastPageArrow );
     var $pageNumberTracker = $( '<span>' )
       .addClass( 'page-number-tracker' )
       .text( copy.page + ' ' )
@@ -370,9 +371,9 @@ var methods = {
 
     $.each( data.pagination.nav.rowCountChoice, function() {
       $( '<button>' )
-        .attr( 'role', 'button' )
-        .text( this )
+        .attr( 'type', 'button' )
         .on( 'click', pageSizeChangeEvent )
+        .text( this )
         .appendTo( pageSizeSelection );
     } );
   },

--- a/timbles.js
+++ b/timbles.js
@@ -46,24 +46,21 @@ var methods = {
 
   // Initialize timble, er, i mean table //
   init: function( opts ) {
-    return this.each( function() {
-      var $this = $( this ).addClass( pluginName );
-      var options = $.extend( {}, defaults, opts );
-      var data = {
-        classes: $.extend( {}, classes, options.classes ),
-        copy: $.extend( {}, copy, options.copy ),
-        dataConfig: methods.parseDataConfig( options.dataConfig ),
-        sorting: options.sorting,
-        pagination: options.pagination
-      };
-      $this.data( pluginName, data );
+    var options = $.extend( {}, opts );
+    var data = {
+      classes: $.extend( {}, classes, options.classes ),
+      copy: $.extend( {}, copy, options.copy ),
+      dataConfig: methods.parseDataConfig( options.dataConfig ),
+      sorting: options.sorting,
+      pagination: options.pagination
+    };
+    this.data( pluginName, data ).addClass( pluginName );
 
-      if ( data.dataConfig ) {
-        methods.generateTableFromJson.call( $this );
-      } else {
-        methods.setupExistingTable.call( $this );
-      }
-    } );
+    if ( data.dataConfig ) {
+      methods.generateTableFromJson.call( this );
+    } else {
+      methods.setupExistingTable.call( this );
+    }
   },
 
   parseDataConfig: function( dataConfig ) {
@@ -438,12 +435,16 @@ var methods = {
 
 // Install timbles jQuery plugin
 $.fn[ pluginName ] = function( method ) {
-  if ( methods.hasOwnProperty( method ) ) {
+  if ( $.isPlainObject( method ) || method === undefined ) {
+    return this.each( function() {
+      methods.init.call( $( this ), method );
+    } );
+  } else if ( methods.hasOwnProperty( method ) ) {
+    var actualMethod = methods[ method ];
     var methodArgs = Array.prototype.slice.call( arguments, 1 );
-    return methods[ method ].apply( this, methodArgs );
-  }
-  if ( typeof method === 'object' || !method ) {
-    return methods.init.apply( this, arguments );
+    return this.each( function() {
+      actualMethod.apply( $( this ), methodArgs );
+    } );
   }
   $.error( 'The method ' + method + ' literally does not exist. Good job.' );
 };

--- a/timbles.js
+++ b/timbles.js
@@ -48,6 +48,8 @@ var methods = {
       var $this = $( this ).addClass( pluginName );
       var options = $.extend( {}, defaults, opts );
       var data = {
+        classes: $.extend( {}, classes, options.classes ),
+        copy: $.extend( {}, copy, options.copy ),
         dataConfig: methods.parseDataConfig( options.dataConfig ),
         sorting: options.sorting,
         pagination: options.pagination
@@ -93,7 +95,7 @@ var methods = {
 
     // For each header cell, store its column number
     var $headerRow = data.$headerRow = this.find( 'thead tr' ).eq( 0 )
-      .addClass( classes.headerRow );
+      .addClass( data.classes.headerRow );
     $headerRow.find( 'th' ).each( function( index ) {
       $( this ).data( 'timbles-column-index', index );
     } );
@@ -105,14 +107,14 @@ var methods = {
   generateTableFromJson: function() {
     var data = this.data( pluginName );
     var $headerRow = data.$headerRow = $( '<tr>' )
-      .addClass( classes.headerRow )
+      .addClass( data.classes.headerRow )
       .appendTo( $( '<thead>' ).appendTo( this ) );
 
     // Generate and add cell headers to header row
     $.each( data.dataConfig.columns, function( index, value ) {
       $( '<th>' )
         .attr( 'id', value.id )
-        .addClass( value.noSorting ? classes.noSort : null )
+        .addClass( value.noSorting ? data.classes.noSort : null )
         .data( 'timbles-column-index', index )
         .text( value.label )
         .appendTo( $headerRow );
@@ -198,12 +200,12 @@ var methods = {
     var sortColumn = $sortHeader.data( 'timbles-column-index' );
 
     if ( !order ) {
-      order = $sortHeader.hasClass( classes.sortASC ) ? 'desc' : 'asc';
+      order = $sortHeader.hasClass( data.classes.sortASC ) ? 'desc' : 'asc';
     }
     data.$headerRow.find( 'th' )
-      .removeClass( classes.sortASC )
-      .removeClass( classes.sortDESC );
-    $sortHeader.addClass( ( order === 'asc' ) ? classes.sortASC : classes.sortDESC );
+      .removeClass( data.classes.sortASC )
+      .removeClass( data.classes.sortDESC );
+    $sortHeader.addClass( ( order === 'asc' ) ? data.classes.sortASC : data.classes.sortDESC );
 
     // Determine column values to actually sort by
     var sortMap = $.map( data.tableRows, function( row ) {
@@ -279,7 +281,7 @@ var methods = {
     var data = this.data( pluginName );
 
     data.$paginationToolsContainer = $( '<div>' )
-      .addClass( classes.paginationToolsContainer )
+      .addClass( data.classes.paginationToolsContainer )
       .insertAfter( this );
 
     if ( !data.pagination.nav ) {
@@ -305,21 +307,21 @@ var methods = {
     var data = this.data( pluginName );
     var $navButton = $( '<button>' ).attr( 'type', 'button' );
 
-    data.$linkFirstPage = $navButton.clone().text( copy.firstPageArrow );
-    data.$linkPrevPage = $navButton.clone().text( copy.prevPageArrow );
-    data.$linkNextPage = $navButton.clone().text( copy.nextPageArrow );
-    data.$linkLastPage = $navButton.clone().text( copy.lastPageArrow );
+    data.$linkFirstPage = $navButton.clone().text( data.copy.firstPageArrow );
+    data.$linkPrevPage = $navButton.clone().text( data.copy.prevPageArrow );
+    data.$linkNextPage = $navButton.clone().text( data.copy.nextPageArrow );
+    data.$linkLastPage = $navButton.clone().text( data.copy.lastPageArrow );
     var $pageNumberTracker = $( '<span>' )
       .addClass( 'page-number-tracker' )
-      .text( copy.page + ' ' )
+      .text( data.copy.page + ' ' )
       .append( $( '<span>' ).addClass( 'pointer-this-page' ).text( data.pagination.currentPage ) )
-      .append( ' ' + copy.of + ' ' )
+      .append( ' ' + data.copy.of + ' ' )
       .append( $( '<span>' ).addClass( 'pointer-last-page' ).text( data.pagination.lastPage ) );
 
     data.$pointerThisPage = $pageNumberTracker.find( '.pointer-this-page' );
     data.$pointerLastPage = $pageNumberTracker.find( '.pointer-last-page' );
     $( '<div>' )
-      .addClass( classes.paginationNavArrows )
+      .addClass( data.classes.paginationNavArrows )
       .append( data.$linkFirstPage )
       .append( data.$linkPrevPage )
       .append( $pageNumberTracker )
@@ -354,12 +356,12 @@ var methods = {
     var data = this.data( pluginName );
 
     pageSizeSelection = $( '<div>' )
-      .addClass( classes.paginationNavRowCountChoice )
+      .addClass( data.classes.paginationNavRowCountChoice )
       .appendTo( data.$paginationToolsContainer );
 
     pageSizeChangeEvent = function( event ) {
-      var $target = $( event.target ).addClass( classes.active );
-      $target.siblings().removeClass( classes.active );
+      var $target = $( event.target ).addClass( data.classes.active );
+      $target.siblings().removeClass( data.classes.active );
       var pageSize = $target.text();
 
       if ( pageSize.toLowerCase() === 'all' ) {
@@ -374,7 +376,7 @@ var methods = {
         .attr( 'type', 'button' )
         .on( 'click', pageSizeChangeEvent )
         .text( this )
-        .toggleClass( classes.active, data.pagination.recordsPerPage === this )
+        .toggleClass( data.classes.active, data.pagination.recordsPerPage === this )
         .appendTo( pageSizeSelection );
     } );
   },
@@ -384,7 +386,7 @@ var methods = {
 
     function toggleButtons( buttons, disabled ) {
       $.each( buttons, function() {
-        this.toggleClass( classes.disabled, disabled );
+        this.toggleClass( data.classes.disabled, disabled );
         this.attr( 'disabled', disabled );
       } );
     }

--- a/timbles.js
+++ b/timbles.js
@@ -382,21 +382,20 @@ var methods = {
   updatePaginationTools: function() {
     var data = this.data( pluginName );
 
-    function toggleButtons( disabled, buttons ) {
+    function toggleButtons( buttons, disabled ) {
       $.each( buttons, function() {
-        var classToggler = ( disabled ) ? this.addClass : this.removeClass;
-        classToggler( classes.disabled );
+        this.toggleClass( classes.disabled, disabled );
         this.attr( 'disabled', disabled );
       } );
     }
 
     // Set buttons inactive if appropriate
     toggleButtons(
-      data.pagination.currentPage === 1,
-      [ data.$linkFirstPage, data.$linkPrevPage ] );
+      [ data.$linkFirstPage, data.$linkPrevPage ],
+      data.pagination.currentPage === 1 );
     toggleButtons(
-      data.pagination.currentPage === data.pagination.lastPage,
-      [ data.$linkLastPage, data.$linkNextPage ] );
+      [ data.$linkLastPage, data.$linkNextPage ],
+      data.pagination.currentPage === data.pagination.lastPage );
 
     // Update page number tracker
     data.$pointerThisPage.text( data.pagination.currentPage );


### PR DESCRIPTION
This builds on the work in PR #31 and improves configurability and the programmatic interface of timbles. Specifically, the following is changed:
- `classes` and `copy` objects can be provided during init. These extend the basic classes/copy objects that are now stored per-table. This resolves #28 and #29 and includes tests
- The main plugin function is changed to provide support for multiple targets on all methods (resolving #23) and support method chaining. This also comes with a test.
