### PR TITLE
Fix bug with sorting sparsely filled columns

### DIFF
--- a/tests/data.json
+++ b/tests/data.json
@@ -5,7 +5,8 @@
     "textNumber": "#11",
     "naturalNumber": 11,
     "percentage": 1,
-    "pets": "Gold fish"
+    "pets": "Gold fish",
+    "sparse": "One"
   },
   {
     "name": "Arthur fforde",
@@ -13,7 +14,8 @@
     "textNumber": "#120",
     "naturalNumber": 120,
     "percentage": 0.05,
-    "pets": "Crickets"
+    "pets": "Crickets",
+    "sparse": "One"
   },
   {
     "name": "Ezra Pound",
@@ -21,7 +23,8 @@
     "textNumber": "#5",
     "naturalNumber": 5,
     "percentage": 0,
-    "pets": "Rabbit"
+    "pets": "Rabbit",
+    "sparse": ""
   },
   {
     "name": "Robert Frost",
@@ -29,7 +32,8 @@
     "textNumber": "#500",
     "naturalNumber": 500,
     "percentage": 0.4545,
-    "pets": "Dog"
+    "pets": "Dog",
+    "sparse": ""
   },
   {
     "name": "Arthur Rimbaud",
@@ -37,6 +41,7 @@
     "textNumber": "#19",
     "naturalNumber": 19,
     "percentage": -1,
-    "pets": "Cat"
+    "pets": "Cat",
+    "sparse": "Two"
   }
 ]

--- a/tests/sorting-array.html
+++ b/tests/sorting-array.html
@@ -27,14 +27,16 @@ $(function() {
       textNumber: "#11",
       naturalNumber: 11,
       percentage: 1,
-      pets: "Gold fish"
+      pets: "Gold fish",
+      sparse: "One"
     }, {
       name: "Arthur fforde",
       lowerName: "Arthur fforde",
       textNumber: "#120",
       naturalNumber: 120,
       percentage: 0.05,
-      pets: "Crickets"
+      pets: "Crickets",
+      sparse: "One"
     },
     {
       name: "Ezra Pound",
@@ -42,7 +44,8 @@ $(function() {
       textNumber: "#5",
       naturalNumber: 5,
       percentage: 0,
-      pets: "Rabbit"
+      pets: "Rabbit",
+      sparse: ""
     },
     {
       name: "Robert Frost",
@@ -50,7 +53,8 @@ $(function() {
       textNumber: "#500",
       naturalNumber: 500,
       percentage: 0.4545,
-      pets: "Dog"
+      pets: "Dog",
+      sparse: ""
     },
     {
       name: "Arthur Rimbaud",
@@ -58,7 +62,8 @@ $(function() {
       textNumber: "#19",
       naturalNumber: 19,
       percentage: -1,
-      pets: "Cat"
+      pets: "Cat",
+      sparse: "Two"
     }
   ];
 
@@ -88,7 +93,8 @@ $(function() {
         { label: 'Text Number', id: 'textNumber'},
         { label: 'Natural number', id: 'naturalNumber', textTransform: numberRanking },
         { label: 'Percentage', id: 'percentage', textTransform: percentageMarkup },
-        { label: 'Unsortable pets', id: 'pets', noSorting: true }
+        { label: 'Unsortable pets', id: 'pets', noSorting: true },
+        { label: 'Sparse column', id: 'sparse' }
       ]
     },
     // if you want sorting:

--- a/tests/sorting-basic.html
+++ b/tests/sorting-basic.html
@@ -19,6 +19,7 @@
         <th>Natural number</th>
         <th>Percentage</th>
         <th class="no-sort">Unsortable pets</th>
+        <th>Sparse</th>
       </tr>
     </thead>
     <tr>
@@ -28,6 +29,7 @@
       <td data-value="11">#11</td>
       <td data-value="1">100%</td>
       <td>Gold fish</td>
+      <td>One</td>
     </tr>
     <tr>
       <td>Arthur fforde</td>
@@ -36,6 +38,7 @@
       <td data-value="120">#120</td>
       <td data-value="0.05">5%</td>
       <td>Crickets</td>
+      <td>One</td>
     </tr>
     <tr>
       <td>Ezra Pound</td>
@@ -44,6 +47,7 @@
       <td data-value="5">#5</td>
       <td data-value="0">0%</td>
       <td>Rabbit</td>
+      <td></td>
     </tr>
     <tr>
       <td>Robert Frost</td>
@@ -52,6 +56,7 @@
       <td data-value="500">#500</td>
       <td data-value="0.4545">45.45%</td>
       <td>Dog</td>
+      <td></td>
     </tr>
     <tr>
       <td>Arthur Rimbaud</td>
@@ -60,6 +65,7 @@
       <td data-value="19">#19</td>
       <td data-value="-1">N/A</td>
       <td>Cat</td>
+      <td>Two</td>
     </tr>
   </table>
 

--- a/tests/sorting-json.html
+++ b/tests/sorting-json.html
@@ -46,7 +46,8 @@ $(function() {
         { label: 'Text Number', id: 'textNumber'},
         { label: 'Natural number', id: 'naturalNumber', textTransform: numberRanking },
         { label: 'Percentage', id: 'percentage', textTransform: percentageMarkup },
-        { label: 'Unsortable pets', id: 'pets', noSorting: true }
+        { label: 'Unsortable pets', id: 'pets', noSorting: true },
+        { label: 'Sparse column', id: 'sparse' }
       ]
     },
     // if you want sorting:

--- a/tests/sorting-paginated.html
+++ b/tests/sorting-paginated.html
@@ -46,7 +46,8 @@ $(function() {
         { label: 'Text Number', id: 'textNumber'},
         { label: 'Natural number', id: 'naturalNumber', textTransform: numberRanking },
         { label: 'Percentage', id: 'percentage', textTransform: percentageMarkup },
-        { label: 'Unsortable pets', id: 'pets', noSorting: true }
+        { label: 'Unsortable pets', id: 'pets', noSorting: true },
+        { label: 'Sparse column', id: 'sparse' }
       ]
     },
     // if you want sorting:

--- a/tests/test-scripts/sorting.js
+++ b/tests/test-scripts/sorting.js
@@ -147,6 +147,13 @@ QUnit.test( 'Sorting reals with zero (percentages)', function( assert ) {
       'Descending order' );
 } );
 
+QUnit.test( 'Sorting unsortable column does nothing', function( assert ) {
+  assert.deepEqual(
+      sortedColumnContent( 5, 'asc' ),
+      sortedColumnContent( 5, 'desc' ),
+      'Ascending/descending sorted content is the same' );
+} );
+
 QUnit.test( 'Sorting sparsely filled columns', function( assert ) {
   var expected = [ '', '', 'One', 'One', 'Two' ];
   assert.deepEqual(

--- a/tests/test-scripts/sorting.js
+++ b/tests/test-scripts/sorting.js
@@ -146,3 +146,16 @@ QUnit.test( 'Sorting reals with zero (percentages)', function( assert ) {
       sliceForPagination( expected ),
       'Descending order' );
 } );
+
+QUnit.test( 'Sorting sparsely filled columns', function( assert ) {
+  var expected = [ '', '', 'One', 'One', 'Two' ];
+  assert.deepEqual(
+      sortedColumnContent( 6 ),
+      sliceForPagination( expected ),
+      'Ascending order' );
+  expected.reverse();
+  assert.deepEqual(
+      sortedColumnContent( 6, 'desc' ),
+      sliceForPagination( expected ),
+      'Descending order' );
+} );

--- a/timbles.js
+++ b/timbles.js
@@ -210,7 +210,7 @@ var methods = {
       var cell = row.children[ sortColumn ];
       var dataValue = cell.getAttribute( 'data-value' );
       if ( dataValue === null ) {
-        dataValue = cell.textContent || cell.innerText;
+        dataValue = cell.textContent || cell.innerText || '';
       } else if ( parseFloat( dataValue ).toString() === dataValue ) {
         dataValue = parseFloat( dataValue );
       }


### PR DESCRIPTION
This PR adds a test to highlight a bug that exists due to a naive compatibility hack that was made to support old-IE. For old-IE support, the value extraction function first checked `textContent`, and if that yielded no result, fell back to `innerText`.

However, when the value of `textContent` is falsy (i.e. empty string) even on modern browsers the value of `innerText` is used. This works fine for browsers that implement `innerText` (which includes Chrome, leading me to not notice this bug earlier), but fails for Firefox (and all browsers that rightfully do not include `innerText`). This causes the sort to fail because comparisons with undefined are always false, which causes the comparison function to consider the values equal (if it's not greater than, nor smaller than, it _must_ be equal).

The included solution is to simply add a second fallthrough value that is the empty string, which was already returned by `textContent`.
