### PR TITLE
Replace header-row class with sort-header-cell classes

### DIFF
--- a/tests/test-scripts/sorting.js
+++ b/tests/test-scripts/sorting.js
@@ -26,14 +26,14 @@ function tablePageSize() {
   return Infinity;
 }
 
-QUnit.test( 'Detect single header row', function( assert ) {
-  var numRows = target.find( 'tr.header-row' ).length;
-  assert.equal( numRows, 1 );
+QUnit.test( 'Count number of sort-enabled header cells', function( assert ) {
+  var sortHeaders = target.find( 'th.timbles-sort-header' ).length;
+  assert.equal( sortHeaders, 6 );
 } );
 
-QUnit.test( 'Correct number of non-header record rows', function( assert ) {
-  var numRows = target.find( 'tr' ).not( '.header-row' ).length;
-  assert.equal( numRows, Math.min( tablePageSize(), 5 ) );
+QUnit.test( 'Correct number of rows in the table body', function( assert ) {
+  var bodyRows = target.find( 'tbody tr' ).length;
+  assert.equal( bodyRows, Math.min( tablePageSize(), 5 ) );
 } );
 
 QUnit.test( 'Clicking a column header sorts table by that column', function( assert ) {


### PR DESCRIPTION
This PR replaces the header-row class with a sort-header class per header cell. This class is attached to those cells that actually have a sorting hook (cells marked `no-sort` will be excluded). This resolves #35.

To address @jennschiffer's [comment](https://github.com/jennschiffer/timbles.js/issues/35#issuecomment-190270079) in that issue:

> That being said, I do think it's a good idea to make the names of things as semantically sound for future module add-ons. I think that columnHeader shouldn't just be restricted to sortable column headers, perhaps activeHeader would be a better class name

The `data.$headerRow` property is replaced with `data.$headers`, a jQuery object of column header cells. Future plugins that need to act on column headers should select them from this object. This way we have a maximally specific class for active table sorting headers, and also support future extension.

Tests have been updated to no longer check for the header row presence, but the expected count of sortHeader classes. Same thing with the non-header-row count, which was essentially a table-body rowcount. That one might even be completely superfluous by now.
