### PR TITLE
Multi row headers

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -10,6 +10,7 @@
   <p>There are a bunch of different ways that tables can be <em>timblified</em>, and all of them need to pass the same tests that verify correct instantiation, data content and sorting.</p>
   <ul>
     <li><a href="sorting-basic.html">Plain html table</a></li>
+    <li><a href="sorting-multi-row-header.html">Plain html table with multi-row header</a></li>
     <li><a href="sorting-array.html">Table created from local array data</a></li>
     <li><a href="sorting-json.html">Table created from JSON file </a></li>
     <li><a href="sorting-paginated.html">Paginated table created from JSON file</a></li>

--- a/tests/index.html
+++ b/tests/index.html
@@ -19,6 +19,7 @@
   <ul>
     <li><a href="pagination.html">Tests for pagination of tables</a></li>
     <li><a href="pagination-post-init.html">Pagination tests where sorting and pagination are set up post-timblification</a></li>
+    <li><a href="multi-row-headers.html">Tests for header cell selection in multi-row headers</a></li>
     <li><a href="misc.html">Miscellaneous other tests of timbles.</a></li>
   </ul>
 </body>

--- a/tests/multi-row-headers.html
+++ b/tests/multi-row-headers.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>timbles tests &bull; QUnit</title>
+  <link rel="stylesheet" href="qunit-1.20.0.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <div id="qunit-fixture"></div>
+
+  <table id="target" border="1" style="display:none;">
+    <thead>
+      <tr>
+        <th id="names" colspan="2">Names</th>
+        <th id="cities" rowspan="2">Cities</th>
+        <th id="numbers" colspan="3">Numbers</th>
+      </tr>
+      <tr>
+        <th id="names-first" >First</th>
+        <th id="names-last" >Last</th>
+        <th id="numbers-low" >Low</th>
+        <th id="numbers-high" >High</th>
+        <th id="numbers-nosort" class="no-sort">Stable</th>
+      </tr>
+    </thead>
+    <tr>
+      <td>Clyde</td>
+      <td>Barrow</td>
+      <td>Madrid</td>
+      <td data-value="4">4</td>
+      <td data-value="372" >372</td>
+      <td>20</td>
+    </tr>
+    <tr>
+      <td>Butch</td>
+      <td>Cassidy</td>
+      <td>Paris</td>
+      <td data-value="1">1</td>
+      <td data-value="924">924</td>
+      <td>44</td>
+    </tr>
+    <tr>
+      <td>Jesse</td>
+      <td>James</td>
+      <td>Moscow</td>
+      <td data-value="7">7</td>
+      <td data-value="563">563</td>
+      <td>31</td>
+    </tr>
+    <tr>
+      <td>John</td>
+      <td>Dillinger</td>
+      <td>Rome</td>
+      <td data-value="5">5</td>
+      <td data-value="1004">1004</td>
+      <td>16</td>
+    </tr>
+  </table>
+
+  <script type="text/javascript" src="../jquery.js"></script>
+  <script type="text/javascript" src="../timbles.js"></script>
+  <script type="text/javascript">
+    $( function() {
+      $( '#target' ).timbles( {
+        sorting: true
+      } );
+    } );
+  </script>
+  <script src="qunit-1.20.0.js"></script>
+  <script>
+    var target = $( '#target' );
+
+    function columnContent( columnIndex ) {
+      return target.find( 'tbody tr' ).map( function() {
+        return $( this ).children().eq( columnIndex ).text();
+      } ).get();
+    }
+
+    QUnit.test( 'Sorting colspanned column headers does nothing', function( assert ) {
+      target.timbles( 'sortColumn', 'names' )
+      sortedNamesOnce = target.find( 'tbody td' ).text()
+      target.timbles( 'sortColumn', 'names' )
+      sortedNamesTwice = target.find( 'tbody td' ).text()
+      assert.equal( sortedNamesOnce, sortedNamesTwice, 'Names column' );
+
+      target.timbles( 'sortColumn', 'numbers' )
+      sortedNumbersOnce = target.find( 'tbody td' ).text()
+      target.timbles( 'sortColumn', 'numbers' )
+      sortedNumbersTwice = target.find( 'tbody td' ).text()
+      assert.equal( sortedNumbersOnce, sortedNumbersTwice, 'Numbers column' );
+    } );
+
+    QUnit.test( 'Rowspanned cities header sorts as expected', function( assert ) {
+      expected = [
+          'Madrid',
+          'Moscow',
+          'Paris',
+          'Rome'
+      ]
+
+      target.find( '#cities' ).click();
+      assert.deepEqual( columnContent( 2 ), expected, 'Ascending, using click event' );
+
+      expected.reverse();
+      target.timbles( 'sortColumn', 2 );
+      assert.deepEqual( columnContent( 2 ), expected, 'Descending, using sortColumn with index' );
+    } );
+
+    QUnit.test( 'Sorting names columns works as intended', function( assert ) {
+      expectedFirst = [
+          'Butch',
+          'Clyde',
+          'Jesse',
+          'John'
+      ]
+      expectedLast = [
+          'Barrow',
+          'Cassidy',
+          'Dillinger',
+          'James'
+      ]
+
+      target.find( '#names-first' ).click();
+      assert.deepEqual( columnContent( 0 ), expectedFirst, 'Ascending, using click event' );
+      target.timbles( 'sortColumn', 'names-last' );
+      assert.deepEqual( columnContent( 1 ), expectedLast, 'Ascending, using sortColumn with ID' );
+
+      expectedFirst.reverse();
+      expectedLast.reverse();
+      target.timbles( 'sortColumn', 'names-first' , 'desc');
+      assert.deepEqual( columnContent( 0 ), expectedFirst, 'Descending, using sortColumn with ID' );
+      target.timbles( 'sortColumn', 1 , 'desc');
+      assert.deepEqual( columnContent( 1 ), expectedLast, 'Descending, using sortColumn with index' );
+    } );
+
+    QUnit.test( 'Number columns sorted by their numeric value', function( assert ) {
+      expectedLow = ['1', '4', '5', '7'];
+      expectedHigh = ['372', '563', '924', '1004'];
+
+      target.find( '#numbers-low' ).click();
+      assert.deepEqual( columnContent( 3 ), expectedLow, 'Ascending, using click event' );
+      target.timbles( 'sortColumn', 'numbers-high' );
+      assert.deepEqual( columnContent( 4 ), expectedHigh, 'Ascending, using sortColumn with ID' );
+
+      expectedLow.reverse();
+      expectedHigh.reverse();
+      target.timbles( 'sortColumn', 'numbers-low', 'desc' );
+      assert.deepEqual( columnContent( 3 ), expectedLow, 'Descending, using sortColumn with ID' );
+      target.timbles( 'sortColumn', 4, 'desc' );
+      assert.deepEqual( columnContent( 4 ), expectedHigh, 'Descending, using sortColumn with index' );
+    } );
+
+    QUnit.test( 'Columns marked "no-sort" do not sort', function( assert ) {
+      initial = target.find( 'tbody td' ).text()
+      target.find( '#numbers-nosort' ).click();
+      assert.equal( target.find( 'tbody td' ).text(), initial, 'Unchanged after first sort attempt' );
+      target.timbles( 'sortColumn', 'numbers-nosort', 'desc' );
+      assert.equal( target.find( 'tbody td' ).text(), initial, 'Unchanged after descending sort attempt' );
+    } );
+
+  </script>
+</body>
+</html>

--- a/tests/sorting-multi-row-header.html
+++ b/tests/sorting-multi-row-header.html
@@ -13,12 +13,17 @@
   <table id="target" border="1" style="display:none;">
     <thead>
       <tr>
-        <th id="name">Name</th>
-        <th>CI name</th>
-        <th>Text number</th>
-        <th>Natural number</th>
+        <th colspan="2">Names</th>
+        <th colspan="3">Numbers</th>
+        <th rowspan="2" class="no-sort">Unsortable pets</th>
+        <th>Extra</th>
+      </tr>
+      <tr>
+        <th id="name">Case sensitive</th>
+        <th>Case insensitive</th>
+        <th>As text</th>
+        <th>Natural</th>
         <th>Percentage</th>
-        <th class="no-sort">Unsortable pets</th>
         <th>Sparse</th>
       </tr>
     </thead>

--- a/tests/test-scripts/sorting.js
+++ b/tests/test-scripts/sorting.js
@@ -37,7 +37,7 @@ QUnit.test( 'Correct number of rows in the table body', function( assert ) {
 } );
 
 QUnit.test( 'Clicking a column header sorts table by that column', function( assert ) {
-  var $firstColumnHeader = target.find( 'thead tr th' ).eq( 0 );
+  var $firstColumnHeader = target.find( '#name' );
   assert.notOk( $firstColumnHeader.hasClass( 'sorted-asc' ), 'Not pre-sorted' );
   $firstColumnHeader.click();
   assert.ok( $firstColumnHeader.hasClass( 'sorted-asc' ), 'Ascending' );
@@ -50,9 +50,9 @@ QUnit.test( 'Clicking a column header sorts table by that column', function( ass
 } );
 
 QUnit.test( 'Applying sortColumn on a header sorted table by that column', function( assert ) {
-  var $firstColumnHeader = target.find( 'thead tr th' ).eq( 0 );
+  var $firstColumnHeader = target.find( '#name' );
   assert.notOk( $firstColumnHeader.hasClass( 'sorted-asc' ), 'Not pre-sorted' );
-  target.timbles( 'sortColumn', 0 );
+  target.timbles( 'sortColumn', 'name' );
   assert.ok( $firstColumnHeader.hasClass( 'sorted-asc' ), 'Ascending' );
   assert.equal( target.find( '.sorted-asc' ).length, 1, 'One ascending sorted col' );
   assert.equal( target.find( '.sorted-desc' ).length, 0, 'No descdending sorted cols' );

--- a/timbles.js
+++ b/timbles.js
@@ -86,12 +86,53 @@ var methods = {
   },
 
   setupExistingTable: function() {
+    var $cell, col, colOffset, colSpan, row, rowOffset, rowSpan;
     var data = this.data( pluginName );
+    var $headerRows = this.find( 'thead tr' );
+    var headerCells = {};
+    var colCount = 0;
 
-    // Select column headers and add column index to them
-    data.$headers = this.find( 'thead th' ).each( function( index ) {
-      $( this ).data( 'timbles-column-index', index );
+    // Resolve col/row-spans and determine column header candidates
+    $headerRows.each( function( rowIndex ) {
+      $( this ).find( 'th' ).each( function( colIndex ) {
+        $cell = $( this );
+
+        // Rowspans cause cells to be in a different place than the DOM suggests
+        while ( headerCells.hasOwnProperty( [ rowIndex, colIndex ] ) ) {
+          colIndex++;
+        }
+
+        // Determine cell size and update table column count
+        rowSpan = parseInt( $cell.attr( 'rowspan' ) ) || 1;
+        colSpan = parseInt( $cell.attr( 'colspan' ) ) || 1;
+        colCount = Math.max( colIndex + colSpan, colCount );
+
+        // Add cell to all 'grid spots' it occupies so we can detect spans
+        // Cells that span multiple columns are never a column header
+        $cell = ( colSpan === 1 ) ? $cell : null;
+        for ( rowOffset = 0; rowOffset < rowSpan; rowOffset++ ) {
+          for ( colOffset = 0; colOffset < colSpan; colOffset++ ) {
+            headerCells[ [ rowIndex + rowOffset, colIndex + colOffset ] ] = $cell;
+          }
+        }
+      } );
     } );
+
+    // Determine actual column headers, search header rows bottom to top
+    var headers = [];
+    for ( col = 0; col < colCount; col++ ) {
+      for ( row = $headerRows.length; row-- > 0; ) {
+        $cell = headerCells[ [ row, col ] ];
+        if ( $cell !== null ) {
+          $cell.data( 'timbles-column-index', col );
+          headers.push( $cell.get( 0 ) );
+          break;
+        }
+      }
+    }
+
+    // Create jQuery object from selected column headers
+    data.$headers = $( headers );
 
     // Start enabling any given features
     methods.enableFeaturesSetup.call( this );

--- a/timbles.js
+++ b/timbles.js
@@ -103,8 +103,8 @@ var methods = {
         }
 
         // Determine cell size and update table column count
-        rowSpan = parseInt( $cell.attr( 'rowspan' ) ) || 1;
-        colSpan = parseInt( $cell.attr( 'colspan' ) ) || 1;
+        rowSpan = parseInt( $cell.attr( 'rowspan' ), 10 ) || 1;
+        colSpan = parseInt( $cell.attr( 'colspan' ), 10 ) || 1;
         colCount = Math.max( colIndex + colSpan, colCount );
 
         // Add cell to all 'grid spots' it occupies so we can detect spans
@@ -411,7 +411,7 @@ var methods = {
         pageSize = data.tableRows.length;
       }
 
-      methods.enablePagination.call( this, parseInt( pageSize ) );
+      methods.enablePagination.call( this, parseInt( pageSize, 10 ) );
     }.bind( this );
 
     $.each( data.pagination.nav.rowCountChoice, function() {


### PR DESCRIPTION
This PR aims to resolve #5.

This multi-row header thing has come up a few times before, and you've mentioned it seems like prime plugin material for reasons of complexity and scope of timbles. However, I find it helps to have code present when having that conversation.
### Code

With the recent changes (#36) of how headers are used, only `setupExistingTables` requires modification. Instead of selecting all `<th>` elements from the table header, it now runs through a more complete process to determine the cells to use as headers.

Since spanned cells create 'gaps' in the DOM, the first step is to create a full mapping of grid positions to cells. Once this grid exists, header selection is as simple as going column by column and picking its header cell.

This has two new behaviors:
1. Cells that span two columns will _never_ be selected for header purposes (because of ambiguity)
2. If a column has multiple `<th>` cells for it, the lowest one is picked

**N.B.** Previously, colspanned cells would sort on click (the leftmost column they spanned), but cells to their right would sort the wrong column. Now, the colspanned cell will _not_ sort on click, but cells to their right will sort the correct column. Both are obviously bad, but the new behavior is arguably slightly less bad.
### Tests

Two test suites are added:
1. A sorting suite that is the same as the basic suite but has an additional header row, to ensure that multi-headed tables pass all the same tests as single-headed tables;
2. A suite specific for multi-row headers, which tests the header selection algorithm.

**N.B.** A small change was made to the sorting test suite. The selection of the first column header is performed using `find( '#name' )` rather than the previous `find( 'thead tr th' ).eq( 0 )`. This is because the additional row causes the cell count to shift, but doesn't change the test itself.
