### PR TITLE
Add plugin support

### DIFF
--- a/timbles.js
+++ b/timbles.js
@@ -437,4 +437,8 @@ $.fn[ pluginName ] = function( method ) {
   $.error( 'The method ' + method + ' literally does not exist. Good job.' );
 };
 
+$.fn[ pluginName ].classes = classes;
+$.fn[ pluginName ].copy = copy;
+$.fn[ pluginName ].methods = methods;
+
 } )( jQuery );

--- a/timbles.js
+++ b/timbles.js
@@ -88,15 +88,30 @@ var methods = {
   configureTable: function() {
     var data = this.data( pluginName );
     data.$headers = methods.selectColumnHeaders.call( this );
+    data.tableRows = methods.selectTableBody.call( this );
 
     // Start enabling any given features
-    methods.enableFeaturesSetup.call( this );
+    if ( data.sorting ) {
+      methods.enableSorting.call( this );
+
+      if ( data.sorting.keyId ) {
+        methods.sortColumn.call( this, data.sorting.keyId, data.sorting.order );
+      }
+    }
+
+    if ( data.pagination ) {
+      methods.enablePagination.call( this, data.pagination.recordsPerPage );
+    }
   },
 
   selectColumnHeaders: function() {
     return this.find( 'thead th' ).each( function( index, cell ) {
       $( cell ).data( 'timbles-column-index', index );
     } );
+  },
+
+  selectTableBody: function() {
+    return this.find( 'tbody tr' ).get();
   },
 
   generateTableFromJson: function() {
@@ -143,23 +158,6 @@ var methods = {
           .appendTo( this );
       }.bind( $newRow ) );
     }.bind( this ) );
-  },
-
-  enableFeaturesSetup: function() {
-    var data = this.data( pluginName );
-    data.tableRows = this.find( 'tbody tr' ).get();
-
-    if ( data.sorting ) {
-      methods.enableSorting.call( this );
-
-      if ( data.sorting.keyId ) {
-        methods.sortColumn.call( this, data.sorting.keyId, data.sorting.order );
-      }
-    }
-
-    if ( data.pagination ) {
-      methods.enablePagination.call( this, data.pagination.recordsPerPage );
-    }
   },
 
   enableSorting: function() {

--- a/timbles.js
+++ b/timbles.js
@@ -116,6 +116,7 @@ var methods = {
 
   generateTableFromJson: function() {
     var data = this.data( pluginName );
+    var generateRows = methods.generateRowsFromData.bind( this, data.dataConfig.columns );
     var $headerRow = $( '<tr>' ).appendTo( $( '<thead>' ).appendTo( this ) );
 
     // Generate header cells and create jQuery object from them
@@ -127,23 +128,17 @@ var methods = {
         .appendTo( $headerRow );
     } );
 
+    // Fill table with provided or linked (JSON) data, then configure it
     if ( $.isArray( data.dataConfig.data ) ) {
-
-      // No need for ajax call if data is local array
-      methods.generateRowsFromData.call( this, data.dataConfig.data, data.dataConfig.columns );
-
-      // Continue configuring the table and enable features
+      generateRows( data.dataConfig.data );
       methods.configureTable.call( this );
     } else {
-
-      // Get external json file given, once loaded and created, configure the table
-      $.getJSON( data.dataConfig.data, function( json ) {
-        methods.generateRowsFromData.call( this, json, data.dataConfig.columns );
-      }.bind( this ) ).then( methods.configureTable.bind( this ) );
+      $.getJSON( data.dataConfig.data, generateRows )
+        .then( methods.configureTable.bind( this ) );
     }
   },
 
-  generateRowsFromData: function( rowData, columnConfig ) {
+  generateRowsFromData: function( columnConfig, rowData ) {
     $.each( rowData, function( index, row ) {
 
       // Add rows to the current table

--- a/timbles.js
+++ b/timbles.js
@@ -104,33 +104,27 @@ var methods = {
     var $headerRow = $( '<tr>' ).appendTo( $( '<thead>' ).appendTo( this ) );
 
     // Generate header cells and create jQuery object from them
-    data.$headers = $( $.map( data.dataConfig.columns, function( value, index ) {
-      return $( '<th>' )
+    $.each( data.dataConfig.columns, function( index, value ) {
+      $( '<th>' )
         .attr( 'id', value.id )
         .addClass( value.noSorting ? data.classes.noSort : null )
-        .data( 'timbles-column-index', index )
         .text( value.label )
-        .appendTo( $headerRow )
-        .get( 0 );
-    } ) );
+        .appendTo( $headerRow );
+    } );
 
     if ( $.isArray( data.dataConfig.data ) ) {
 
       // No need for ajax call if data is local array
       methods.generateRowsFromData.call( this, data.dataConfig.data, data.dataConfig.columns );
 
-      // Start enabling any given features
-      methods.enableFeaturesSetup.call( this );
+      // Continue configuring the table and enable features
+      methods.configureTable.call( this );
     } else {
 
-      // Get external json file given
+      // Get external json file given, once loaded and created, configure the table
       $.getJSON( data.dataConfig.data, function( json ) {
         methods.generateRowsFromData.call( this, json, data.dataConfig.columns );
-      }.bind( this ) ).then( function() {
-
-        // Start enabling any given features
-        methods.enableFeaturesSetup.call( this );
-      }.bind( this ) );
+      }.bind( this ) ).then( methods.configureTable.bind( this ) );
     }
   },
 

--- a/timbles.js
+++ b/timbles.js
@@ -370,7 +370,7 @@ var methods = {
         pageSize = data.tableRows.length;
       }
 
-      methods.enablePagination.call( this, parseInt( pageSize ) );
+      methods.enablePagination.call( this, parseInt( pageSize, 10 ) );
     }.bind( this );
 
     $.each( data.pagination.nav.rowCountChoice, function() {

--- a/timbles.js
+++ b/timbles.js
@@ -55,7 +55,7 @@ var methods = {
     if ( data.dataConfig ) {
       methods.generateTableFromJson.call( this );
     } else {
-      methods.setupExistingTable.call( this );
+      methods.configureTable.call( this );
     }
   },
 
@@ -85,16 +85,18 @@ var methods = {
     return dataConfig;
   },
 
-  setupExistingTable: function() {
+  configureTable: function() {
     var data = this.data( pluginName );
-
-    // Select column headers and add column index to them
-    data.$headers = this.find( 'thead th' ).each( function( index ) {
-      $( this ).data( 'timbles-column-index', index );
-    } );
+    data.$headers = methods.selectColumnHeaders.call( this );
 
     // Start enabling any given features
     methods.enableFeaturesSetup.call( this );
+  },
+
+  selectColumnHeaders: function() {
+    return this.find( 'thead th' ).each( function( index, cell ) {
+      $( cell ).data( 'timbles-column-index', index );
+    } );
   },
 
   generateTableFromJson: function() {


### PR DESCRIPTION
Hey @jennschiffer,

In order for #5 to be handled in an extension, some things need to be exposed (methods), and it makes sense to make some other small changes in the name of single-responsibility. So this PR brings the following (API) changes:
1. Header cell selection is moved to the function `selectColumnHeaders()`, no longer split between pre-existing tables and generated ones
2. Creating the `tableRows` 'cache' is also moved to a function, `selectTableBody()`
3. These two operations and the enabling of features are done in the `configureTable()` function, which is executed for both pre-existing and generated tables. This replaces `setupExistingTable()` and `enableFeatures()` and makes the two kinds of tables more similar in operation.
4. Expose objects `classes`, `copy` and `methods` to the outside world, allowing plugins to hook into / replace methods with altered behavior.

Exposing all the methods wholesale like this feels a bit crude, but I don't see a clear and better way (though there probably _is_).

Other small changes:
- Argument swap on `generateRowsFromData()` which allows for a significant simplification of generating table content from Array / JSON;
- Radix inclusion in the `parseInt()`  call.
