### PR TITLE
Add support for inverted sort directions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timbles",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "a p chill jQuery table plugin, made by people who literally did not invent tables",
   "main": "timbles",
   "directories": {

--- a/tests/data.json
+++ b/tests/data.json
@@ -6,7 +6,8 @@
     "naturalNumber": 11,
     "percentage": 1,
     "pets": "Gold fish",
-    "sparse": "One"
+    "sparse": "One",
+    "inverse": "Macao"
   },
   {
     "name": "Arthur fforde",
@@ -15,7 +16,8 @@
     "naturalNumber": 120,
     "percentage": 0.05,
     "pets": "Crickets",
-    "sparse": "One"
+    "sparse": "One",
+    "inverse": "Zimbabwe"
   },
   {
     "name": "Ezra Pound",
@@ -24,7 +26,8 @@
     "naturalNumber": 5,
     "percentage": 0,
     "pets": "Rabbit",
-    "sparse": ""
+    "sparse": "",
+    "inverse": ""
   },
   {
     "name": "Robert Frost",
@@ -33,7 +36,8 @@
     "naturalNumber": 500,
     "percentage": 0.4545,
     "pets": "Dog",
-    "sparse": ""
+    "sparse": "",
+    "inverse": "Brazil"
   },
   {
     "name": "Arthur Rimbaud",
@@ -42,6 +46,7 @@
     "naturalNumber": 19,
     "percentage": -1,
     "pets": "Cat",
-    "sparse": "Two"
+    "sparse": "Two",
+    "inverse": "Honduras"
   }
 ]

--- a/tests/sorting-array.html
+++ b/tests/sorting-array.html
@@ -28,7 +28,8 @@ $(function() {
       naturalNumber: 11,
       percentage: 1,
       pets: "Gold fish",
-      sparse: "One"
+      sparse: "One",
+      inverse: "Macao"
     }, {
       name: "Arthur fforde",
       lowerName: "Arthur fforde",
@@ -36,7 +37,8 @@ $(function() {
       naturalNumber: 120,
       percentage: 0.05,
       pets: "Crickets",
-      sparse: "One"
+      sparse: "One",
+      inverse: "Zimbabwe"
     },
     {
       name: "Ezra Pound",
@@ -45,7 +47,8 @@ $(function() {
       naturalNumber: 5,
       percentage: 0,
       pets: "Rabbit",
-      sparse: ""
+      sparse: "",
+      inverse: ""
     },
     {
       name: "Robert Frost",
@@ -54,7 +57,8 @@ $(function() {
       naturalNumber: 500,
       percentage: 0.4545,
       pets: "Dog",
-      sparse: ""
+      sparse: "",
+      inverse: "Brazil",
     },
     {
       name: "Arthur Rimbaud",
@@ -63,7 +67,8 @@ $(function() {
       naturalNumber: 19,
       percentage: -1,
       pets: "Cat",
-      sparse: "Two"
+      sparse: "Two",
+      inverse: "Honduras"
     }
   ];
 
@@ -94,7 +99,8 @@ $(function() {
         { label: 'Natural number', id: 'naturalNumber', textTransform: numberRanking },
         { label: 'Percentage', id: 'percentage', textTransform: percentageMarkup },
         { label: 'Unsortable pets', id: 'pets', noSorting: true },
-        { label: 'Sparse column', id: 'sparse' }
+        { label: 'Sparse column', id: 'sparse' },
+        { label: 'Inverted column', id: 'inverse', inverseSort: true }
       ]
     },
     // if you want sorting:

--- a/tests/sorting-basic.html
+++ b/tests/sorting-basic.html
@@ -20,6 +20,7 @@
         <th>Percentage</th>
         <th class="no-sort">Unsortable pets</th>
         <th>Sparse</th>
+        <th class="inverse-sort">Inverted</th>
       </tr>
     </thead>
     <tr>
@@ -30,6 +31,7 @@
       <td data-value="1">100%</td>
       <td>Gold fish</td>
       <td>One</td>
+      <td>Macao</td>
     </tr>
     <tr>
       <td>Arthur fforde</td>
@@ -39,6 +41,7 @@
       <td data-value="0.05">5%</td>
       <td>Crickets</td>
       <td>One</td>
+      <td>Zimbabwe</td>
     </tr>
     <tr>
       <td>Ezra Pound</td>
@@ -47,6 +50,7 @@
       <td data-value="5">#5</td>
       <td data-value="0">0%</td>
       <td>Rabbit</td>
+      <td></td>
       <td></td>
     </tr>
     <tr>
@@ -57,6 +61,7 @@
       <td data-value="0.4545">45.45%</td>
       <td>Dog</td>
       <td></td>
+      <td>Brazil</td>
     </tr>
     <tr>
       <td>Arthur Rimbaud</td>
@@ -66,6 +71,7 @@
       <td data-value="-1">N/A</td>
       <td>Cat</td>
       <td>Two</td>
+      <td>Honduras</td>
     </tr>
   </table>
 

--- a/tests/sorting-json.html
+++ b/tests/sorting-json.html
@@ -47,7 +47,8 @@ $(function() {
         { label: 'Natural number', id: 'naturalNumber', textTransform: numberRanking },
         { label: 'Percentage', id: 'percentage', textTransform: percentageMarkup },
         { label: 'Unsortable pets', id: 'pets', noSorting: true },
-        { label: 'Sparse column', id: 'sparse' }
+        { label: 'Sparse column', id: 'sparse' },
+        { label: 'Inverted column', id: 'inverse', inverseSort: true }
       ]
     },
     // if you want sorting:

--- a/tests/sorting-paginated.html
+++ b/tests/sorting-paginated.html
@@ -47,7 +47,8 @@ $(function() {
         { label: 'Natural number', id: 'naturalNumber', textTransform: numberRanking },
         { label: 'Percentage', id: 'percentage', textTransform: percentageMarkup },
         { label: 'Unsortable pets', id: 'pets', noSorting: true },
-        { label: 'Sparse column', id: 'sparse' }
+        { label: 'Sparse column', id: 'sparse' },
+        { label: 'Inverted column', id: 'inverse', inverseSort: true }
       ]
     },
     // if you want sorting:

--- a/tests/test-scripts/sorting.js
+++ b/tests/test-scripts/sorting.js
@@ -2,13 +2,19 @@
 
 var target = $( '#target' );
 
+function getColumnContent( columnIndex ) {
+  /* Returns an array with the column contents
+   */
+  return target.find( 'tbody tr' ).map( function() {
+    return $( this ).children().eq( columnIndex ).text();
+  } ).get();
+}
+
 function sortedColumnContent( columnIndex, order ) {
   /* Sorts by the given column and returns an array with the column contents
    */
   target.timbles( 'sortColumn', columnIndex, order || 'asc' );
-  return target.find( 'tbody tr' ).map( function() {
-    return $( this ).children().eq( columnIndex ).text();
-  } ).get();
+  return getColumnContent( columnIndex );
 }
 
 function sliceForPagination( elements ) {
@@ -28,7 +34,7 @@ function tablePageSize() {
 
 QUnit.test( 'Count number of sort-enabled header cells', function( assert ) {
   var sortHeaders = target.find( 'th.timbles-sort-header' ).length;
-  assert.equal( sortHeaders, 6 );
+  assert.equal( sortHeaders, 7 );
 } );
 
 QUnit.test( 'Correct number of rows in the table body', function( assert ) {
@@ -165,4 +171,19 @@ QUnit.test( 'Sorting sparsely filled columns', function( assert ) {
       sortedColumnContent( 6, 'desc' ),
       sliceForPagination( expected ),
       'Descending order' );
+} );
+
+QUnit.test( 'Sorting inverse-sorted columns', function( assert ) {
+  var expected = [ 'Zimbabwe', 'Macao', 'Honduras', 'Brazil', '' ];
+  target.timbles( 'sortColumn', 7 );
+  assert.deepEqual(
+      getColumnContent( 7 ),
+      sliceForPagination( expected ),
+      'Descending order' );
+  expected.reverse();
+  target.timbles( 'sortColumn', 7 );
+  assert.deepEqual(
+      getColumnContent( 7 ),
+      sliceForPagination( expected ),
+      'Ascending order' );
 } );

--- a/timbles.js
+++ b/timbles.js
@@ -93,10 +93,6 @@ var methods = {
     // Start enabling any given features
     if ( data.sorting ) {
       methods.enableSorting.call( this );
-
-      if ( data.sorting.keyId ) {
-        methods.sortColumn.call( this, data.sorting.keyId, data.sorting.order );
-      }
     }
 
     if ( data.pagination ) {
@@ -160,6 +156,10 @@ var methods = {
     data.$headers.not( '.' + data.classes.noSort )
       .addClass( data.classes.sortHeader )
       .on( 'click', methods.sortColumnEvent.bind( this ) );
+
+    if ( data.sorting && data.sorting.keyId ) {
+      methods.sortColumn.call( this, data.sorting.keyId, data.sorting.order );
+    }
   },
 
   sortColumn: function( key, order ) {

--- a/timbles.js
+++ b/timbles.js
@@ -19,6 +19,7 @@ var classes = {
   sortHeader: 'timbles-sort-header',
   sortASC: 'sorted-asc',
   sortDESC: 'sorted-desc',
+  inverseSort: 'inverse-sort',
   noSort: 'no-sort',
   navigationCurrentPage: 'pointer-this-page',
   navigationLastPage: 'pointer-last-page',
@@ -120,6 +121,7 @@ var methods = {
       $( '<th>' )
         .attr( 'id', value.id )
         .addClass( value.noSorting ? data.classes.noSort : null )
+        .addClass( value.inverseSort ? data.classes.inverseSort : null )
         .text( value.label )
         .appendTo( $headerRow );
     } );
@@ -183,7 +185,15 @@ var methods = {
     var sortColumn = $sortHeader.data( 'timbles-column-index' );
 
     if ( !order ) {
-      order = $sortHeader.hasClass( data.classes.sortASC ) ? 'desc' : 'asc';
+      if ( $sortHeader.hasClass( data.classes.sortASC ) ) {
+        order = 'desc';
+      } else if ( $sortHeader.hasClass( data.classes.sortDESC ) ) {
+        order = 'asc';
+      } else if ( $sortHeader.hasClass( data.classes.inverseSort ) ) {
+        order = 'desc';
+      } else {
+        order = 'asc';
+      }
     }
     data.$headers
       .removeClass( data.classes.sortASC )


### PR DESCRIPTION
This PR adds support for a `inverse-sort` class on the column header which will cause the initial sort direction to be inverted. That is, upon first click the column will be sorted in descending order. Repeated sort events of the same column will continue as before, alternating ascending and descending.

Sorting by another column and then returning to the `inverse-sort` column will have it sort in descending order again. Each initial sort will be in the other direction from the current behavior.