### PR TITLE
Fix TypeError with nested column header cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timbles",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "a p chill jQuery table plugin, made by people who literally did not invent tables",
   "main": "timbles",
   "directories": {

--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,7 @@ It will add a very simple first/prev/next/last pagination navigation on the bott
 When you sort ascending, the `sort-asc` class is added to the `<th>` header. If you sort descending, the `sort-desc` class is added to the `<th>` header. So you can, like, use CSS to add arrows whenever those classes are set and that's p cool I think.
 
 ## Changelog
+* 1.1.6 fixes bug with nested columns header clicks
 * 1.1.5 add initial inverse sort support
 * 1.1.4 prepare to plug in (a refactor for future features)
 * 1.1.3 pagination refactor, testing refactor, so much faster!

--- a/tests/misc.html
+++ b/tests/misc.html
@@ -58,6 +58,17 @@
       </tbody>
     </table>
 
+    <table id="nested-column-header">
+      <thead>
+        <tr><th><span><strong>Header</strong></span></th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Z</td></tr>
+        <tr><td>Y</td></tr>
+        <tr><td>X</td></tr>
+      </tbody>
+    </table>
+
   </div>
   <script type="text/javascript" src="../jquery.js"></script>
   <script type="text/javascript" src="../timbles.js"></script>
@@ -122,6 +133,12 @@
       assert.equal( multiTable.length, 2, 'Actually selected two tables' );
       assert.equal( $( '#multi-target-one tbody td' ).text(), 'B', 'First table followed' );
       assert.equal( $( '#multi-target-two tbody td' ).text(), 'F', 'Second table followed' );
+    } );
+
+    QUnit.test( 'Nested column headers sort as normal', function( assert ) {
+      var target = $( '#nested-column-header' ).timbles( { sorting: true } );
+      target.find( 'th strong' ).click();
+      assert.equal( target.find( 'td' ).eq( 0 ).text(), 'X');
     } );
 
   </script>

--- a/timbles.js
+++ b/timbles.js
@@ -181,7 +181,7 @@ var methods = {
     var data = this.data( pluginName );
 
     // Determine order and update header sort classes
-    var $sortHeader = $( event.target );
+    var $sortHeader = $( event.currentTarget );
     var sortColumn = $sortHeader.data( 'timbles-column-index' );
 
     if ( !order ) {


### PR DESCRIPTION
Fixes a bug where clicking on a nested column header (`<th><span>Header</span></th>`) would cause a TypeError due to the incorrect event target being read. Reading the column header from `event.currentTarget` instead of `event.target` fixes this.

Included is the fix itself, a test, version bump and changelog update.